### PR TITLE
ci: add GitHub Actions workflow (lint/typecheck/tests/sqlmesh/soda)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,132 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Ruff (lint + format)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - name: Install
+        run: uv sync --all-extras --dev
+      - name: ruff check
+        run: uv run ruff check .
+      - name: ruff format --check
+        run: uv run ruff format --check .
+
+  typecheck:
+    name: mypy
+    runs-on: ubuntu-latest
+    # 31 pre-existing errors across noaa/usgs/ebird sources + orchestration.
+    # Soft-fail until a dedicated follow-up ticket lands; job still reports status.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - name: Install
+        run: uv sync --all-extras --dev
+      - name: mypy
+        run: uv run mypy packages/ --ignore-missing-imports
+
+  tests:
+    name: pytest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - name: Install
+        run: uv sync --all-extras --dev
+      - name: pytest
+        # Exit 5 = "no tests collected". Tolerate until source-test-harness ticket lands.
+        run: |
+          set +e
+          uv run pytest
+          code=$?
+          if [ "$code" -eq 5 ]; then
+            echo "::warning::pytest collected zero tests — source-test-harness ticket pending."
+            exit 0
+          fi
+          exit $code
+
+  sqlmesh-lint:
+    name: SQLMesh lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - name: Install
+        run: uv sync --all-extras --dev
+      - name: sqlmesh lint
+        env:
+          DATABOX_GATEWAY: local
+        run: uv run sqlmesh --paths transforms/main lint
+
+  soda-validate:
+    name: Soda contract structure
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - name: Install
+        run: uv sync --all-extras --dev
+      - name: Validate Soda contract YAML structure
+        # Soda CLI requires a live data source; no schema-only mode exists.
+        # This job statically validates every contract parses as YAML and has
+        # the two required top-level keys. Live `soda contract verify` runs as
+        # a Dagster asset check after materialization (see observability-pass ticket).
+        run: |
+          uv run python - <<'PY'
+          from pathlib import Path
+          import sys, yaml
+
+          root = Path("soda/contracts")
+          required = ("dataset", "columns")
+          errors: list[str] = []
+          files = sorted(list(root.rglob("*.yaml")) + list(root.rglob("*.yml")))
+          if not files:
+              sys.exit("no Soda contracts found under soda/contracts/")
+          for p in files:
+              try:
+                  doc = yaml.safe_load(p.read_text())
+              except yaml.YAMLError as e:
+                  errors.append(f"{p}: YAML parse error: {e}")
+                  continue
+              if not isinstance(doc, dict):
+                  errors.append(f"{p}: top-level is not a mapping")
+                  continue
+              for key in required:
+                  if key not in doc:
+                      errors.append(f"{p}: missing required top-level key '{key}'")
+          if errors:
+              print("Soda contract validation failed:")
+              for e in errors:
+                  print(f"  - {e}")
+              sys.exit(1)
+          print(f"All {len(files)} Soda contracts have valid structure.")
+          PY

--- a/.loom/evidence/20260420-ci-dry-run.md
+++ b/.loom/evidence/20260420-ci-dry-run.md
@@ -1,0 +1,44 @@
+---
+id: evidence:ci-dry-run-iter1
+kind: evidence
+status: active
+created_at: 2026-04-20T00:00:00Z
+updated_at: 2026-04-20T00:00:00Z
+scope:
+  kind: workspace
+links:
+  ticket: ticket:ci-github-actions
+  packet: packet:ci-github-actions-iter1
+---
+
+# What
+
+Local dry-run of every job defined in `.github/workflows/ci.yaml` against the current `main` tree, using an isolated environment (`env -i`) to simulate CI's empty env.
+
+# Results
+
+| Job             | Command                                                                                      | Exit | Note                                                                    |
+| --------------- | -------------------------------------------------------------------------------------------- | ---- | ----------------------------------------------------------------------- |
+| `lint`          | `uv run ruff check .` + `uv run ruff format --check .`                                        | 0, 0 | Clean.                                                                  |
+| `typecheck`     | `uv run mypy packages/ --ignore-missing-imports`                                             | 1    | 31 pre-existing errors across noaa/usgs/ebird/orchestration. Soft-fail. |
+| `tests`         | `uv run pytest`                                                                              | 5    | Zero tests collected. Workflow maps exit 5 to success + annotation.      |
+| `sqlmesh-lint`  | `DATABOX_GATEWAY=local uv run sqlmesh --paths transforms/main lint`                          | 0    | Silent pass.                                                            |
+| `soda-validate` | inline Python validator over `soda/contracts/**/*.yaml`                                      | 0    | `files=22 errors=0`.                                                    |
+
+# Notes
+
+- Isolated env was required locally because `.env` contains `MOTHERDUCK_TOKEN`, `DATABOX_BACKEND=motherduck`, `DATABOX_GATEWAY=motherduck`, which override the CI-intended `local` gateway. CI won't have `.env`, so this is a local-only concern.
+- `.env` previously had a stale `SQLMESH_GATEWAY=postgres` line pointing at a non-existent gateway. Removed as part of this work.
+- `sqlmesh plan` is unsuitable for CI without pre-seeded raw tables — staging models reference `raw_<source>.main.<table>` for schema introspection. `sqlmesh lint` is the right gate for this phase; plan-level gating lands in `ticket:schema-contract-ci` (Phase 2, local-enforced).
+- `soda contract verify` requires a live data source in Soda Core v4.7.0. No schema-only flag exists. The CI job statically validates YAML structure (required keys `dataset`, `columns`) instead; live contract verification happens as a Dagster asset check per `ticket:observability-pass`.
+
+# Action SHAs resolved
+
+- `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5` (v4.3.1)
+- `astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b` (v8.1.0)
+
+# Residual risks / follow-ups
+
+- `typecheck` is soft-fail. Need a dedicated ticket to resolve the 31 mypy errors (mostly pendulum type-union drift in `noaa/source.py` and `usgs/source.py`, one dlt return type in `ebird/source.py`, one motherduck subclass in `orchestration/definitions.py`).
+- `tests` tolerates zero-collected. Will flip to strict once `ticket:source-test-harness` lands.
+- Cache-hit verification cannot happen locally — confirm on second CI run.

--- a/.loom/packets/20260420-cuh5h45n-ci-github-actions.md
+++ b/.loom/packets/20260420-cuh5h45n-ci-github-actions.md
@@ -144,8 +144,26 @@ Do not touch:
 
 # Child Output
 
-_(filled by worker on return)_
+Spawned subagent stream-timed-out after ~2h of local validation (49 tool calls) without writing artifacts. Parent reconciled by executing the iteration inline, holding to the packet's scope and stop conditions.
+
+- **outcome**: `continue`
+- **files changed**:
+  - `/Users/crlough/Code/personal/databox/.github/workflows/ci.yaml` (new)
+  - `/Users/crlough/Code/personal/databox/README.md` (badge inserted)
+  - `/Users/crlough/Code/personal/databox/.env` (removed stale `SQLMESH_GATEWAY=postgres` + stale `SQLMESH_PROJECT_ROOT`)
+  - `/Users/crlough/Code/personal/databox/.loom/tickets/20260420-tzy3q8i9-ci-github-actions.md` (status + work log)
+  - `/Users/crlough/Code/personal/databox/.loom/evidence/20260420-ci-dry-run.md` (new)
+- **commands / outcomes**: see `.loom/evidence/20260420-ci-dry-run.md`
+- **deviations**:
+  - Used `sqlmesh lint` instead of `sqlmesh plan` (plan requires raw tables; proper gating lives in `ticket:schema-contract-ci`).
+  - Used static YAML validator instead of `soda contract verify` (Soda Core v4.7.0 has no schema-only mode).
+  - `typecheck` job marked `continue-on-error: true` per packet stop condition (31 pre-existing mypy errors); triggers follow-up ticket.
+  - `tests` job tolerates exit 5 until source-test-harness ticket lands.
+- **residual risks**: workflow not yet pushed / verified in GitHub UI; cache-hit unconfirmed; mypy soft-fail needs follow-up; no deliberate-failure branch run yet.
+- **recommended ticket state**: `review_required` until push-to-branch verification happens, then `complete_pending_acceptance`.
 
 # Parent Merge Notes
 
-_(filled by parent after return)_
+- Agent transport failed (idle timeout) but the packet's Source Snapshot and Stop Conditions were specific enough to let the parent finish inline without re-deriving context. Future Ralph iterations on long-running validation work should set a tighter per-command timeout or pre-populate fixtures so the child can finish in under the transport window.
+- Two new follow-up tickets recommended: `follow-up/mypy-cleanup` and (optional) `follow-up/dependabot-actions`.
+- Ticket not closed. Parent will push branch, confirm green, then advance.

--- a/.loom/tickets/20260420-tzy3q8i9-ci-github-actions.md
+++ b/.loom/tickets/20260420-tzy3q8i9-ci-github-actions.md
@@ -1,7 +1,7 @@
 ---
 id: ticket:ci-github-actions
 kind: ticket
-status: ready
+status: review_required
 created_at: 2026-04-20T00:00:00Z
 updated_at: 2026-04-20T00:00:00Z
 scope:
@@ -59,3 +59,30 @@ No CI exists today. A recruiter will check the GitHub Actions tab and the README
 
 - Link to a passing workflow run on `main`
 - Link to a deliberately-failing branch showing each gate can fail
+
+# Work Log
+
+## Iter 1 — 2026-04-20
+
+- Landed `.github/workflows/ci.yaml` with five jobs: `lint`, `typecheck`, `tests`, `sqlmesh-lint`, `soda-validate`.
+- Added CI badge to `README.md` linking at the workflow.
+- Scrubbed stale `SQLMESH_GATEWAY=postgres` from `.env` (pointed at a non-existent gateway).
+- Deviations from ticket's original "In Scope":
+  - **SQLMesh step is `sqlmesh lint`, not `sqlmesh plan`.** `plan` requires raw tables to exist for schema introspection; pre-seeding them in CI is scope creep. Plan-level gating belongs to `ticket:schema-contract-ci` (Phase 2).
+  - **Soda step is static YAML structure validation, not `soda contract verify`.** Soda Core v4.7.0 requires a live data source; no schema-only mode. Live verification already belongs on the Dagster asset-check path per `ticket:observability-pass`.
+  - **`typecheck` job is `continue-on-error: true`.** 31 pre-existing mypy errors; resolving them is scope creep for this ticket. Follow-up needed.
+  - **`tests` job tolerates pytest exit 5** (zero collected) until `ticket:source-test-harness` populates tests.
+- Dry-run evidence: `.loom/evidence/20260420-ci-dry-run.md`.
+- Third-party action SHAs pinned, tag names in trailing comments.
+- Did not add `.github/dependabot.yaml` — defer.
+
+## Residual risks / follow-ups (suggest new tickets or fold into existing)
+
+- **follow-up/mypy-cleanup** (new ticket): resolve 31 pre-existing mypy errors, flip `continue-on-error` off.
+- **follow-up/pytest-strict**: flip zero-collected tolerance off once `ticket:source-test-harness` lands.
+- **Cache-hit verification**: confirm on second CI run, update evidence.
+- **Real end-to-end verification** still pending: workflow has not actually been pushed to GitHub yet. Next action is to push a throwaway branch, confirm green + confirm each gate can fail, link both runs, then move to `complete_pending_acceptance`.
+
+## Recommended next state
+
+`review_required` → push to a branch, verify CI runs, then `complete_pending_acceptance`.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Databox
 
+[![CI](https://github.com/Doctacon/databox/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/Doctacon/databox/actions/workflows/ci.yaml)
+
 A dataset-agnostic data platform for ingestion, transformation, quality checking, and visualization. Zero-infra local mode (file-based DuckDB) with a one-flag switch to MotherDuck cloud. Orchestrated end-to-end by Dagster.
 
 ## Stack

--- a/packages/databox-orchestration/pyproject.toml
+++ b/packages/databox-orchestration/pyproject.toml
@@ -20,4 +20,4 @@ build-backend = "setuptools.build_meta"
 [tool.uv.sources]
 databox-config = { workspace = true }
 databox-sources = { workspace = true }
-dagster-sqlmesh = { git = "ssh://git@github.com/Doctacon/dagster-sqlmesh.git" }
+dagster-sqlmesh = { git = "https://github.com/Doctacon/dagster-sqlmesh.git" }

--- a/uv.lock
+++ b/uv.lock
@@ -380,7 +380,7 @@ wheels = [
 [[package]]
 name = "dagster-sqlmesh"
 version = "0.22.0"
-source = { git = "ssh://git@github.com/Doctacon/dagster-sqlmesh.git#cd56c588f1e81c2ef14f25c58b5ef7a4d9e56288" }
+source = { git = "https://github.com/Doctacon/dagster-sqlmesh.git#cd56c588f1e81c2ef14f25c58b5ef7a4d9e56288" }
 dependencies = [
     { name = "dagster" },
     { name = "pyarrow" },
@@ -486,7 +486,7 @@ dependencies = [
 requires-dist = [
     { name = "dagster", specifier = ">=1.5.0" },
     { name = "dagster-dlt", specifier = ">=0.1.0" },
-    { name = "dagster-sqlmesh", git = "ssh://git@github.com/Doctacon/dagster-sqlmesh.git" },
+    { name = "dagster-sqlmesh", git = "https://github.com/Doctacon/dagster-sqlmesh.git" },
     { name = "dagster-webserver", specifier = ">=1.5.0" },
     { name = "databox-config", editable = "packages/databox-config" },
     { name = "databox-sources", editable = "packages/databox-sources" },


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/ci.yaml` with five jobs: `lint`, `typecheck`, `tests`, `sqlmesh-lint`, `soda-validate`.
- Third-party actions pinned to commit SHAs (v4.3.1 checkout, v8.1.0 setup-uv).
- Caching keyed on `uv.lock`. Concurrency group cancels superseded runs on the same ref.
- Adds CI badge to `README.md`.
- Scrubs stale `SQLMESH_GATEWAY=postgres` / `SQLMESH_PROJECT_ROOT` from `.env` (untracked).

## Deviations from original ticket

- `sqlmesh lint` instead of `sqlmesh plan`. Plan requires raw tables to exist for schema introspection — pre-seeding is scope creep. Plan-level gating moves to `ticket:schema-contract-ci` (Phase 2, local-enforced).
- Static Soda YAML validator instead of `soda contract verify`. Soda Core v4.7.0 requires a live data source; no schema-only mode. Live verification stays on the Dagster asset-check path per `ticket:observability-pass`.
- `typecheck` is `continue-on-error: true` — 31 pre-existing mypy errors. Tracked as follow-up.
- `tests` tolerates pytest exit 5 (zero collected) until `ticket:source-test-harness` lands.

## Test plan

- [ ] PR triggers all five jobs; `lint`, `tests`, `sqlmesh-lint`, `soda-validate` green
- [ ] `typecheck` runs, surfaces pre-existing errors as a soft-fail annotation
- [ ] Second run reuses `uv` cache (look for `Cache restored` in logs)
- [ ] Deliberate-failure branch verifies each gate can fail (follow-up run after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)