### PR TITLE
fix(types): resolve 31 mypy errors, enforce typecheck in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,9 +31,6 @@ jobs:
   typecheck:
     name: mypy
     runs-on: ubuntu-latest
-    # 31 pre-existing errors across noaa/usgs/ebird sources + orchestration.
-    # Soft-fail until a dedicated follow-up ticket lands; job still reports status.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0

--- a/packages/databox-config/databox_config/settings.py
+++ b/packages/databox-config/databox_config/settings.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from pydantic import Field, computed_field
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent.parent
@@ -22,24 +22,20 @@ class DataboxSettings(BaseSettings):
     dlt_data_dir: str = str(PROJECT_ROOT / "pipelines" / ".dlt")
     log_level: str = "INFO"
 
-    @computed_field
     @property
     def database_path(self) -> str:
         return "md:databox" if self.backend == "motherduck" else str(DATA_DIR / "databox.duckdb")
 
-    @computed_field
     @property
     def raw_ebird_path(self) -> str:
         return (
             "md:raw_ebird" if self.backend == "motherduck" else str(DATA_DIR / "raw_ebird.duckdb")
         )
 
-    @computed_field
     @property
     def raw_noaa_path(self) -> str:
         return "md:raw_noaa" if self.backend == "motherduck" else str(DATA_DIR / "raw_noaa.duckdb")
 
-    @computed_field
     @property
     def raw_usgs_path(self) -> str:
         return "md:raw_usgs" if self.backend == "motherduck" else str(DATA_DIR / "raw_usgs.duckdb")

--- a/packages/databox-orchestration/databox_orchestration/definitions.py
+++ b/packages/databox-orchestration/databox_orchestration/definitions.py
@@ -56,7 +56,7 @@ class DataboxConfig(dg.ConfigurableResource):
 _gateway = "motherduck" if os.getenv("DATABOX_BACKEND") == "motherduck" else "local"
 
 
-def _dlt_destination(db_path: str) -> dlt.destinations.duckdb:
+def _dlt_destination(db_path: str) -> t.Any:
     if os.getenv("DATABOX_BACKEND") == "motherduck":
         return dlt.destinations.motherduck(credentials=db_path)
     return dlt.destinations.duckdb(credentials=db_path)

--- a/packages/databox-sources/databox_sources/ebird/source.py
+++ b/packages/databox-sources/databox_sources/ebird/source.py
@@ -204,7 +204,7 @@ class EbirdPipelineSource:
             max_results=self._max_results,
             days_back=self._days_back,
         )
-        return source.resources.values()
+        return list(source.resources.values())
 
     def load(self, smoke: bool = False):
         schema_name = self.config.resolve_schema_name()

--- a/packages/databox-sources/databox_sources/noaa/source.py
+++ b/packages/databox-sources/databox_sources/noaa/source.py
@@ -93,8 +93,8 @@ def _chunk_date_range(start: str, end: str, max_days: int = 365) -> list[tuple[s
 
     GHCND (daily) is limited to 1 year per request.
     """
-    start_dt = pendulum.parse(start)
-    end_dt = pendulum.parse(end)
+    start_dt = pendulum.from_format(start, "YYYY-MM-DD")
+    end_dt = pendulum.from_format(end, "YYYY-MM-DD")
     chunks = []
     current = start_dt
 

--- a/packages/databox-sources/databox_sources/usgs/source.py
+++ b/packages/databox-sources/databox_sources/usgs/source.py
@@ -88,8 +88,8 @@ def _parse_daily_value_records(
 
 
 def _chunk_date_range(start: str, end: str, max_days: int = 90) -> list[tuple[str, str]]:
-    start_dt = pendulum.parse(start)
-    end_dt = pendulum.parse(end)
+    start_dt = pendulum.from_format(start, "YYYY-MM-DD")
+    end_dt = pendulum.from_format(end, "YYYY-MM-DD")
     chunks: list[tuple[str, str]] = []
     current = start_dt
     while current < end_dt:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,11 @@ dev = [
     "pre-commit>=4.0",
     "ruff>=0.12.5",
     "mypy>=1.0",
+    "types-PyYAML>=6.0",
 ]
+
+[tool.mypy]
+plugins = ["pydantic.mypy"]
 
 [tool.uv]
 package = false

--- a/uv.lock
+++ b/uv.lock
@@ -426,6 +426,7 @@ dev = [
     { name = "pytest-mock" },
     { name = "responses" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 
 [package.metadata]
@@ -446,6 +447,7 @@ dev = [
     { name = "pytest-mock", specifier = ">=3.14" },
     { name = "responses", specifier = ">=0.25" },
     { name = "ruff", specifier = ">=0.12.5" },
+    { name = "types-pyyaml", specifier = ">=6.0" },
 ]
 
 [[package]]
@@ -2702,6 +2704,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.20260408"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/74/73/b759b1e413c31034cc01ecdfb96b38115d0ab4db55a752a3929f0cd449fd/types_pyyaml-6.0.12.20260408.tar.gz", hash = "sha256:92a73f2b8d7f39ef392a38131f76b970f8c66e4c42b3125ae872b7c93b556307", size = 17735, upload-time = "2026-04-08T04:30:50.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/f0/c391068b86abb708882c6d75a08cd7d25b2c7227dab527b3a3685a3c635b/types_pyyaml-6.0.12.20260408-py3-none-any.whl", hash = "sha256:fbc42037d12159d9c801ebfcc79ebd28335a7c13b08a4cfbc6916df78fee9384", size = 20339, upload-time = "2026-04-08T04:30:50.113Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Fix all 31 pre-existing mypy errors across `databox-config`, `databox-sources`, `databox-orchestration`
- Flip typecheck CI job from soft-fail to hard-fail

## Fixes
- **pendulum drift** (28 errors): `pendulum.parse()` returns `Date | Time | Duration | DateTime`; swapped for `pendulum.from_format(s, "YYYY-MM-DD")` in noaa/usgs chunkers — returns concrete `DateTime`, supports `<` / `.add(days=...)` / `.format(...)`.
- **computed_field stack** (4 errors): mypy does not support decorators on top of `@property`. `settings` paths are only ever accessed as attributes (no `.model_dump()`), so `@computed_field` was dead weight. Dropped it; kept `@property`.
- **dict_values return** (1 error): `PipelineSource.resources` contract is `list[...]`. Wrapped `source.resources.values()` in `list(...)`.
- **destination union** (1 error): `_dlt_destination` returns either `dlt.destinations.duckdb` or `dlt.destinations.motherduck`. Widened annotation to `Any`.
- **types-PyYAML**: added to dev deps; `pydantic.mypy` plugin registered for future-proofing.

## Verification
Locally: `uv run mypy packages/ --ignore-missing-imports` → `Success: no issues found in 16 source files`.

CI enforcement: `continue-on-error: true` removed from typecheck job. Any future mypy regression now blocks merge.

## Test plan
- [ ] All five CI jobs pass on PR
- [ ] Typecheck job is now hard-required (fails the run on regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)