### PR TITLE
ci: schema-contract gate with PR-body escape hatch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,6 +72,33 @@ jobs:
           DATABOX_GATEWAY: local
         run: uv run sqlmesh --paths transforms/main lint
 
+  schema-contract-gate:
+    name: Schema contract gate
+    runs-on: ubuntu-latest
+    # Only meaningful on PRs — pushes to main have no base ref to diff against.
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+        with:
+          # Need full history so `origin/main` resolves for the diff base.
+          fetch-depth: 0
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - name: Install
+        run: uv sync --all-extras --dev
+      - name: Write PR body to file
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          printf '%s' "$PR_BODY" > /tmp/pr_body.txt
+      - name: Run schema-contract gate
+        run: |
+          uv run python scripts/schema_gate.py \
+            --base origin/${{ github.base_ref }} \
+            --pr-body-file /tmp/pr_body.txt
+
   soda-validate:
     name: Soda contract structure
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ task typecheck      # mypy
 task test           # pytest
 ```
 
+See [docs/contracts.md](docs/contracts.md) for the schema-contract gate and the
+`accept-breaking-change` escape hatch used on PRs that intentionally break
+downstream consumers.
+
 ## License
 
 MIT

--- a/docs/contracts.md
+++ b/docs/contracts.md
@@ -1,0 +1,71 @@
+# Schema Contracts
+
+Databox treats Soda contracts under `soda/contracts/` as the public schema for every SQLMesh-owned dataset. Contracts are enforced three ways:
+
+1. **Structural validation** — every PR runs `soda-validate` to confirm each contract parses as YAML and has `dataset` + `columns` keys.
+2. **Runtime checks** — after each materialization, a Dagster asset check invokes `soda contract verify` against the materialized table. A contract violation fails the check (and the run).
+3. **Schema-contract gate** — on every PR, `schema-contract-gate` diffs the contracts at HEAD against `origin/<base>` and fails the build if a breaking change is not explicitly acknowledged.
+
+This page covers #3 — the gate, what it catches, and how to override it when you really mean to break downstream consumers.
+
+## What counts as breaking
+
+The gate classifies each contract change into one of two buckets.
+
+### Breaking (fail closed)
+
+- **Model removed** — a contract file under `soda/contracts/**` deleted
+- **Column removed** — a column that existed at the base is gone at HEAD
+- **Type narrowed** — a column's `data_type` changed to a non-widening type (e.g. `bigint` → `int`, `text` → `varchar` is fine but `timestamp` → `date` is not)
+- **Model renamed** — the top-level `dataset` identifier changed
+
+### Additive (always safe)
+
+- New contract file
+- New column
+- Widened type (`int` → `bigint`, `date` → `timestamp`, etc.)
+- New check
+
+The classifier is in `scripts/schema_gate.py`; the type-widening table lives in `_SAFE_TYPE_WIDENINGS`.
+
+## How the gate runs
+
+The `schema-contract-gate` CI job:
+
+1. Checks out with `fetch-depth: 0` so `origin/<base_ref>` resolves.
+2. Reads every `*.yaml` under `soda/contracts/` at the base and at HEAD.
+3. Classifies each change.
+4. Exits `0` if clean or fully acknowledged, `1` if any breaking change is unacknowledged, `2` on invocation error (git failure, invalid YAML).
+
+The job only runs on `pull_request` events — pushes to `main` have no sensible base to diff against.
+
+## Acknowledging a breaking change
+
+Breaking changes are sometimes the right call — retiring a deprecated column, collapsing a mart, renaming a model after a domain change. When that happens, add an `accept-breaking-change` line to the PR body, one per model:
+
+```
+accept-breaking-change: ebird.fct_daily_bird_observations
+accept-breaking-change: noaa.fct_daily_weather
+```
+
+The token the gate matches on is the contract's `dataset` field (not the file path). The gate prints the full report either way — acknowledged breaking changes are annotated `(ACKED)` in the output so reviewers can still see them at a glance.
+
+Use the escape hatch when:
+
+- the consumer of the removed column/model is being retired in the same PR
+- the breaking change is the intended outcome of a versioned migration
+- you have coordinated with downstream readers out of band
+
+Do not use it to silence a drift you did not intend. If the diff surprises you, that is the gate doing its job.
+
+## Running the gate locally
+
+```bash
+uv run python scripts/schema_gate.py --base origin/main
+```
+
+Flags:
+
+- `--base <ref>` — revision to compare HEAD against (default `origin/main`)
+- `--pr-body-file <path>` — file containing the PR body, for parsing `accept-breaking-change` tokens
+- `--accept a.b,c.d` — comma-separated list of models whose breaking change is acknowledged; overrides the `ACCEPT_BREAKING_CHANGE` env var

--- a/scripts/schema_gate.py
+++ b/scripts/schema_gate.py
@@ -1,0 +1,288 @@
+"""Schema-contract gate — compare Soda contract YAMLs at HEAD against a base
+revision (usually `main`) and fail on breaking changes unless explicitly
+acknowledged.
+
+A "breaking change" is:
+  - a Soda contract file removed (model removed)
+  - a column removed from a contract (column dropped)
+  - a column's declared `data_type` changed to a non-widening type
+  - the contract's `dataset` identifier changed (model renamed)
+
+Additive changes (new contract, new column, new check) are always safe.
+
+Usage:
+    python scripts/schema_gate.py --base origin/main
+    python scripts/schema_gate.py --base origin/main --accept ebird.fct_daily_bird_observations
+
+Exit codes:
+  0 — no breaking changes, or all breaking changes acknowledged
+  1 — breaking changes found and not acknowledged
+  2 — invocation error (missing base ref, git failure, invalid YAML, etc.)
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+CONTRACTS_DIR = Path("soda/contracts")
+
+# Non-widening type transitions. Keys are current type, values are types the
+# column may safely change TO. Everything else is considered breaking.
+_SAFE_TYPE_WIDENINGS: dict[str, set[str]] = {
+    "int": {"bigint", "decimal", "double", "float"},
+    "integer": {"bigint", "decimal", "double", "float"},
+    "smallint": {"int", "integer", "bigint", "decimal", "double", "float"},
+    "bigint": {"decimal", "double"},
+    "float": {"double"},
+    "varchar": {"text", "string"},
+    "text": {"varchar", "string"},
+    "date": {"timestamp"},
+}
+
+
+@dataclass
+class ContractChange:
+    model: str
+    kind: str  # "model_removed", "column_removed", "type_narrowed", "model_renamed"
+    detail: str
+
+
+@dataclass
+class Report:
+    breaking: list[ContractChange] = field(default_factory=list)
+    additive: list[ContractChange] = field(default_factory=list)
+
+    @property
+    def has_breaking(self) -> bool:
+        return bool(self.breaking)
+
+
+def _run(cmd: list[str]) -> str:
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"git failed: {' '.join(cmd)}\n{result.stderr.strip()}")
+    return result.stdout
+
+
+def _list_contracts_at(revision: str) -> dict[str, str]:
+    """Return {path: yaml_content} for every .yaml under CONTRACTS_DIR at revision."""
+    listing = _run(["git", "ls-tree", "-r", "--name-only", revision, str(CONTRACTS_DIR)])
+    out: dict[str, str] = {}
+    for path in listing.splitlines():
+        if not path.endswith(".yaml"):
+            continue
+        out[path] = _run(["git", "show", f"{revision}:{path}"])
+    return out
+
+
+def _list_contracts_head() -> dict[str, str]:
+    out: dict[str, str] = {}
+    for path in CONTRACTS_DIR.rglob("*.yaml"):
+        out[str(path)] = path.read_text()
+    return out
+
+
+def _parse(text: str, path: str) -> dict[str, Any]:
+    try:
+        doc = yaml.safe_load(text) or {}
+    except yaml.YAMLError as exc:
+        raise RuntimeError(f"invalid YAML in {path}: {exc}") from exc
+    if not isinstance(doc, dict):
+        raise RuntimeError(f"{path}: expected mapping at root")
+    return doc
+
+
+def _columns(doc: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    """Return {column_name: {data_type: ...}} for each declared column."""
+    cols = doc.get("columns") or []
+    out: dict[str, dict[str, Any]] = {}
+    for col in cols:
+        if not isinstance(col, dict) or "name" not in col:
+            continue
+        out[col["name"]] = {"data_type": col.get("data_type")}
+    return out
+
+
+def _is_breaking_type_change(old: str | None, new: str | None) -> bool:
+    if old is None or new is None:
+        return False  # can't classify without both
+    old_n, new_n = old.lower().strip(), new.lower().strip()
+    if old_n == new_n:
+        return False
+    safe_targets = _SAFE_TYPE_WIDENINGS.get(old_n, set())
+    return new_n not in safe_targets
+
+
+def diff(base_contracts: dict[str, str], head_contracts: dict[str, str]) -> Report:
+    report = Report()
+
+    base_paths = set(base_contracts)
+    head_paths = set(head_contracts)
+
+    for removed_path in sorted(base_paths - head_paths):
+        base_doc = _parse(base_contracts[removed_path], removed_path)
+        model = base_doc.get("dataset", removed_path)
+        report.breaking.append(
+            ContractChange(
+                model=model,
+                kind="model_removed",
+                detail=f"contract {removed_path} was removed",
+            )
+        )
+
+    for added_path in sorted(head_paths - base_paths):
+        head_doc = _parse(head_contracts[added_path], added_path)
+        model = head_doc.get("dataset", added_path)
+        report.additive.append(
+            ContractChange(model=model, kind="model_added", detail=f"new contract {added_path}")
+        )
+
+    for path in sorted(base_paths & head_paths):
+        base_doc = _parse(base_contracts[path], path)
+        head_doc = _parse(head_contracts[path], path)
+        model = head_doc.get("dataset", path)
+
+        base_dataset = base_doc.get("dataset")
+        head_dataset = head_doc.get("dataset")
+        if base_dataset and head_dataset and base_dataset != head_dataset:
+            report.breaking.append(
+                ContractChange(
+                    model=model,
+                    kind="model_renamed",
+                    detail=f"dataset changed: {base_dataset} -> {head_dataset}",
+                )
+            )
+
+        base_cols = _columns(base_doc)
+        head_cols = _columns(head_doc)
+
+        for removed_col in sorted(set(base_cols) - set(head_cols)):
+            report.breaking.append(
+                ContractChange(
+                    model=model,
+                    kind="column_removed",
+                    detail=f"column '{removed_col}' dropped",
+                )
+            )
+
+        for added_col in sorted(set(head_cols) - set(base_cols)):
+            report.additive.append(
+                ContractChange(
+                    model=model,
+                    kind="column_added",
+                    detail=f"new column '{added_col}'",
+                )
+            )
+
+        for col in sorted(set(base_cols) & set(head_cols)):
+            old_type = base_cols[col]["data_type"]
+            new_type = head_cols[col]["data_type"]
+            if _is_breaking_type_change(old_type, new_type):
+                report.breaking.append(
+                    ContractChange(
+                        model=model,
+                        kind="type_narrowed",
+                        detail=f"column '{col}': {old_type} -> {new_type}",
+                    )
+                )
+
+    return report
+
+
+def acknowledgements(pr_body: str | None, env_override: str | None) -> set[str]:
+    """Collect models whose breaking changes the author has explicitly accepted."""
+    acked: set[str] = set()
+    if env_override:
+        acked.update(part.strip() for part in env_override.split(",") if part.strip())
+    if pr_body:
+        for match in re.finditer(r"^\s*accept-breaking-change:\s*([^\s]+)", pr_body, re.MULTILINE):
+            acked.add(match.group(1).strip())
+    return acked
+
+
+def format_report(report: Report, acknowledged: set[str]) -> str:
+    lines: list[str] = []
+    if report.additive:
+        lines.append("Additive changes (safe):")
+        for change in report.additive:
+            lines.append(f"  + [{change.model}] {change.detail}")
+        lines.append("")
+    if report.breaking:
+        lines.append("Breaking changes:")
+        for change in report.breaking:
+            status = " (ACKED)" if change.model in acknowledged else ""
+            lines.append(f"  ! [{change.model}]{status} {change.kind}: {change.detail}")
+        lines.append("")
+    if not report.additive and not report.breaking:
+        lines.append("No contract changes.")
+    return "\n".join(lines).rstrip()
+
+
+def run_gate(base: str, pr_body: str | None, env_override: str | None) -> int:
+    base_contracts = _list_contracts_at(base)
+    head_contracts = _list_contracts_head()
+    report = diff(base_contracts, head_contracts)
+    acked = acknowledgements(pr_body, env_override)
+    print(format_report(report, acked))
+
+    if not report.has_breaking:
+        return 0
+
+    unacked = [c for c in report.breaking if c.model not in acked]
+    if not unacked:
+        print("\nAll breaking changes acknowledged via accept-breaking-change.")
+        return 0
+
+    print("\nFAIL: unacknowledged breaking changes.", file=sys.stderr)
+    print(
+        "To acknowledge, add `accept-breaking-change: <model>` to the PR body "
+        "(one line per model).",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--base", default="origin/main", help="git revision to compare HEAD against"
+    )
+    parser.add_argument(
+        "--pr-body-file",
+        default=None,
+        help="path to a file containing the PR body (for ack-token parsing)",
+    )
+    parser.add_argument(
+        "--accept",
+        default=None,
+        help=(
+            "comma-separated list of models whose breaking change is acknowledged"
+            " (overrides ACCEPT_BREAKING_CHANGE env var)"
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    pr_body: str | None = None
+    if args.pr_body_file:
+        pr_body = Path(args.pr_body_file).read_text()
+
+    env_override = args.accept or os.environ.get("ACCEPT_BREAKING_CHANGE")
+
+    try:
+        return run_gate(args.base, pr_body, env_override)
+    except RuntimeError as exc:
+        print(f"schema-gate error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_schema_gate.py
+++ b/tests/test_schema_gate.py
@@ -1,0 +1,143 @@
+"""Unit tests for scripts/schema_gate.py classifier.
+
+These tests exercise the diff classifier in isolation — no git, no file I/O.
+CI covers the end-to-end path with a real `origin/main` base ref.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "schema_gate.py"
+spec = importlib.util.spec_from_file_location("schema_gate", SCRIPT)
+schema_gate = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+assert spec and spec.loader
+sys.modules["schema_gate"] = schema_gate
+spec.loader.exec_module(schema_gate)  # type: ignore[union-attr]
+
+diff = schema_gate.diff
+acknowledgements = schema_gate.acknowledgements
+
+
+def _contract(dataset: str, columns: list[dict[str, object]]) -> str:
+    lines = [f"dataset: {dataset}", "columns:"]
+    for col in columns:
+        lines.append(f"  - name: {col['name']}")
+        if "data_type" in col:
+            lines.append(f"    data_type: {col['data_type']}")
+    return "\n".join(lines) + "\n"
+
+
+# --------------------------------------------------------------------------- #
+# diff classifier
+# --------------------------------------------------------------------------- #
+
+
+def test_add_column_is_additive() -> None:
+    base = {"c.yaml": _contract("x.y", [{"name": "a"}])}
+    head = {"c.yaml": _contract("x.y", [{"name": "a"}, {"name": "b"}])}
+    report = diff(base, head)
+    assert not report.has_breaking
+    assert len(report.additive) == 1
+    assert report.additive[0].kind == "column_added"
+    assert "b" in report.additive[0].detail
+
+
+def test_drop_column_is_breaking() -> None:
+    base = {"c.yaml": _contract("x.y", [{"name": "a"}, {"name": "b"}])}
+    head = {"c.yaml": _contract("x.y", [{"name": "a"}])}
+    report = diff(base, head)
+    assert report.has_breaking
+    assert report.breaking[0].kind == "column_removed"
+    assert "b" in report.breaking[0].detail
+
+
+def test_rename_column_shows_as_drop_plus_add() -> None:
+    base = {"c.yaml": _contract("x.y", [{"name": "old_name"}])}
+    head = {"c.yaml": _contract("x.y", [{"name": "new_name"}])}
+    report = diff(base, head)
+    assert any(c.kind == "column_removed" for c in report.breaking)
+    assert any(c.kind == "column_added" for c in report.additive)
+
+
+def test_widen_type_is_additive() -> None:
+    base = {"c.yaml": _contract("x.y", [{"name": "a", "data_type": "int"}])}
+    head = {"c.yaml": _contract("x.y", [{"name": "a", "data_type": "bigint"}])}
+    report = diff(base, head)
+    assert not report.has_breaking
+
+
+def test_narrow_type_is_breaking() -> None:
+    base = {"c.yaml": _contract("x.y", [{"name": "a", "data_type": "bigint"}])}
+    head = {"c.yaml": _contract("x.y", [{"name": "a", "data_type": "int"}])}
+    report = diff(base, head)
+    assert report.has_breaking
+    assert report.breaking[0].kind == "type_narrowed"
+
+
+def test_add_model_is_additive() -> None:
+    base: dict[str, str] = {}
+    head = {"c.yaml": _contract("x.y", [{"name": "a"}])}
+    report = diff(base, head)
+    assert not report.has_breaking
+    assert report.additive[0].kind == "model_added"
+
+
+def test_remove_model_is_breaking() -> None:
+    base = {"c.yaml": _contract("x.y", [{"name": "a"}])}
+    head: dict[str, str] = {}
+    report = diff(base, head)
+    assert report.has_breaking
+    assert report.breaking[0].kind == "model_removed"
+
+
+def test_rename_model_is_breaking() -> None:
+    base = {"c.yaml": _contract("x.old", [{"name": "a"}])}
+    head = {"c.yaml": _contract("x.new", [{"name": "a"}])}
+    report = diff(base, head)
+    assert any(c.kind == "model_renamed" for c in report.breaking)
+
+
+def test_no_changes_is_clean() -> None:
+    base = {"c.yaml": _contract("x.y", [{"name": "a"}])}
+    head = {"c.yaml": _contract("x.y", [{"name": "a"}])}
+    report = diff(base, head)
+    assert not report.has_breaking
+    assert not report.additive
+
+
+# --------------------------------------------------------------------------- #
+# acknowledgement parsing
+# --------------------------------------------------------------------------- #
+
+
+def test_ack_from_env_only() -> None:
+    assert acknowledgements(pr_body=None, env_override="a.b, c.d") == {"a.b", "c.d"}
+
+
+def test_ack_from_pr_body_single() -> None:
+    body = "Some PR summary\n\naccept-breaking-change: ebird.fct_daily_bird_observations\n"
+    assert acknowledgements(body, None) == {"ebird.fct_daily_bird_observations"}
+
+
+def test_ack_from_pr_body_multiple() -> None:
+    body = (
+        "Dropping two columns intentionally:\n"
+        "accept-breaking-change: ebird.fct_daily_bird_observations\n"
+        "accept-breaking-change: noaa.fct_daily_weather\n"
+    )
+    assert acknowledgements(body, None) == {
+        "ebird.fct_daily_bird_observations",
+        "noaa.fct_daily_weather",
+    }
+
+
+def test_ack_env_and_pr_body_merge() -> None:
+    body = "accept-breaking-change: model-a"
+    assert acknowledgements(body, "model-b") == {"model-a", "model-b"}
+
+
+def test_ack_none_when_neither_supplied() -> None:
+    assert acknowledgements(None, None) == set()


### PR DESCRIPTION
## Summary
- Diff Soda contracts at HEAD vs `origin/<base>` on every PR; fail closed on model/column removal, dataset rename, or non-widening type change.
- Escape hatch: `accept-breaking-change: <dataset>` in the PR body (one line per dataset). Acked changes still show in the report annotated `(ACKED)`.
- Classifier is Soda-contract-first (no SQLMesh state required in CI), so the gate stays hermetic.

## What ships
- `scripts/schema_gate.py` — classifier + CLI (`--base`, `--pr-body-file`, `--accept`); exit 0 clean/acked, 1 unacked breaking, 2 invocation error
- `tests/test_schema_gate.py` — 14 unit tests (diff classifier + ack parsing)
- `.github/workflows/ci.yaml` — new `schema-contract-gate` job, PR-only
- `docs/contracts.md` — gate behavior, breaking vs additive, when to use the escape hatch; linked from README

## Test plan
- [x] `uv run ruff check` + `ruff format --check` — clean
- [x] `uv run mypy scripts/schema_gate.py` — clean
- [x] `uv run pytest tests/test_schema_gate.py` — 14/14 pass
- [x] Manual smoke: clean diff → exit 0; simulated column drop → exit 1; with `--accept` → exit 0 + `(ACKED)` annotation
- [ ] CI green on this PR (gate runs against itself; should be clean since no contracts changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)