### PR TITLE
feat(analytics): flagship cross-domain mart

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,11 @@ See [docs/incremental-loading.md](docs/incremental-loading.md) for the
 per-resource write disposition, primary keys, idempotency guarantee, and
 backfill commands.
 
+See [docs/analytics-examples.md](docs/analytics-examples.md) for example
+queries against the flagship cross-domain mart
+(`analytics.fct_species_environment_daily`) that joins eBird observations
+with NOAA weather and USGS streamflow at species × H3 cell × day grain.
+
 ## License
 
 MIT

--- a/docs/analytics-examples.md
+++ b/docs/analytics-examples.md
@@ -1,0 +1,130 @@
+# Analytics Examples
+
+Example queries against the flagship cross-domain mart, `analytics.fct_species_environment_daily`.
+
+## The Mart
+
+`analytics.fct_species_environment_daily` joins three sources at **species × H3 cell (resolution 6, ~36 km² hex) × day** grain:
+
+| Source | Values |
+|--------|--------|
+| eBird | `n_observations`, `n_checklists`, `total_birds_counted`, `n_notable_observations` |
+| NOAA | `tmax_c`, `tmin_c`, `temp_range_c`, `prcp_mm`, `snow_mm`, `wind_ms`, `is_rainy_day`, `nearest_station_id`, `nearest_station_distance_miles` |
+| USGS | `mean_discharge_cfs`, `mean_gage_height_ft`, `mean_water_temp_c`, `nearest_gauge_id`, `nearest_gauge_distance_miles` |
+
+The grain is unique on `(species_code, h3_cell, obs_date)`. Weather and streamflow are LEFT-joined — when the nearest station/gauge has no observation for a given date, the environmental columns are NULL. (NOAA GHCND data has a multi-day publish lag, so recent dates frequently have NULL weather.)
+
+## Example 1 — Species on Cold, Rainy Days
+
+Which species show up in cold (tmax < 15 °C), rainy cells?
+
+```sql
+SELECT
+    common_name,
+    SUM(n_observations) AS obs,
+    ROUND(AVG(prcp_mm)::NUMERIC, 2) AS avg_prcp_mm,
+    ROUND(AVG(tmax_c)::NUMERIC, 1) AS avg_tmax_c
+FROM databox.analytics.fct_species_environment_daily
+WHERE is_rainy_day
+  AND tmax_c < 15
+GROUP BY common_name
+ORDER BY obs DESC
+LIMIT 20;
+```
+
+## Example 2 — Species Diversity by H3 Cell
+
+Which cells have the highest species diversity, and what does the weather look like there?
+
+```sql
+SELECT
+    h3_cell,
+    ROUND(AVG(cell_center_lat)::NUMERIC, 3) AS lat,
+    ROUND(AVG(cell_center_lng)::NUMERIC, 3) AS lng,
+    COUNT(DISTINCT species_code) AS species_count,
+    SUM(n_observations) AS obs,
+    ROUND(AVG(tmax_c)::NUMERIC, 1) AS avg_tmax_c,
+    ROUND(AVG(prcp_mm)::NUMERIC, 2) AS avg_prcp_mm
+FROM databox.analytics.fct_species_environment_daily
+GROUP BY h3_cell
+ORDER BY species_count DESC
+LIMIT 10;
+```
+
+## Example 3 — Bird Activity vs. Streamflow Regime
+
+Do bird counts cluster at low-flow, medium-flow, or high-flow gauges?
+
+```sql
+SELECT
+    CASE
+        WHEN mean_discharge_cfs < 100 THEN 'low'
+        WHEN mean_discharge_cfs < 1000 THEN 'medium'
+        ELSE 'high'
+    END AS flow_bucket,
+    COUNT(DISTINCT species_code) AS species,
+    SUM(n_observations) AS obs,
+    ROUND(AVG(mean_discharge_cfs)::NUMERIC, 1) AS avg_cfs
+FROM databox.analytics.fct_species_environment_daily
+WHERE mean_discharge_cfs IS NOT NULL
+GROUP BY 1
+ORDER BY 1;
+```
+
+## Example 4 — Cold-Snap-After-Rainfall Species
+
+Species seen the day after a rainy day where tmax dropped ≥ 5 °C compared to the previous day:
+
+```sql
+WITH daily AS (
+    SELECT
+        species_code,
+        common_name,
+        h3_cell,
+        obs_date,
+        tmax_c,
+        prcp_mm,
+        n_observations,
+        LAG(tmax_c) OVER (PARTITION BY h3_cell ORDER BY obs_date) AS prev_tmax_c,
+        LAG(prcp_mm) OVER (PARTITION BY h3_cell ORDER BY obs_date) AS prev_prcp_mm
+    FROM databox.analytics.fct_species_environment_daily
+)
+SELECT
+    common_name,
+    COUNT(DISTINCT obs_date) AS days_seen,
+    SUM(n_observations) AS obs
+FROM daily
+WHERE prev_prcp_mm > 5.0
+  AND prev_tmax_c - tmax_c >= 5.0
+GROUP BY common_name
+ORDER BY obs DESC
+LIMIT 10;
+```
+
+## Running the Queries
+
+### MotherDuck
+
+```bash
+uv run python -c "
+import os, duckdb
+con = duckdb.connect(f'md:databox?motherduck_token={os.environ[\"MOTHERDUCK_TOKEN\"]}')
+print(con.execute('SELECT COUNT(*) FROM analytics.fct_species_environment_daily').fetchone())
+"
+```
+
+### Local DuckDB
+
+```bash
+uv run python -c "
+import duckdb
+con = duckdb.connect('data/databox.duckdb')
+print(con.execute('SELECT COUNT(*) FROM analytics.fct_species_environment_daily').fetchone())
+"
+```
+
+Or point the Streamlit explorer at the same database:
+
+```bash
+uv run streamlit run app/main.py
+```

--- a/packages/databox-orchestration/databox_orchestration/definitions.py
+++ b/packages/databox-orchestration/databox_orchestration/definitions.py
@@ -302,6 +302,10 @@ _soda_checks: list[dg.AssetChecksDefinition] = [
         SODA_DIR / "contracts/analytics/platform_health.yaml",
     ),
     create_soda_asset_check(
+        dg.AssetKey(["sqlmesh", "analytics", "fct_species_environment_daily"]),
+        SODA_DIR / "contracts/analytics/fct_species_environment_daily.yaml",
+    ),
+    create_soda_asset_check(
         dg.AssetKey(["sqlmesh", "usgs_staging", "stg_usgs_daily_values"]),
         SODA_DIR / "contracts/usgs_staging/stg_usgs_daily_values.yaml",
     ),
@@ -345,6 +349,7 @@ _usgs_sqlmesh_keys = [
 _analytics_sqlmesh_keys = [
     dg.AssetKey(["sqlmesh", "analytics", "fct_bird_weather_daily"]),
     dg.AssetKey(["sqlmesh", "analytics", "fct_species_weather_preferences"]),
+    dg.AssetKey(["sqlmesh", "analytics", "fct_species_environment_daily"]),
     dg.AssetKey(["sqlmesh", "analytics", "platform_health"]),
 ]
 

--- a/soda/contracts/analytics/fct_species_environment_daily.yaml
+++ b/soda/contracts/analytics/fct_species_environment_daily.yaml
@@ -1,0 +1,85 @@
+dataset: databox/analytics/fct_species_environment_daily
+
+columns:
+  - name: species_code
+    data_type: text
+    checks:
+      - missing:
+          must_be: 0
+  - name: common_name
+    data_type: text
+  - name: scientific_name
+    data_type: text
+  - name: h3_cell
+    data_type: text
+    checks:
+      - missing:
+          must_be: 0
+  - name: obs_date
+    data_type: date
+    checks:
+      - missing:
+          must_be: 0
+
+  - name: n_observations
+    data_type: bigint
+    checks:
+      - missing:
+          must_be: 0
+  - name: n_checklists
+    data_type: bigint
+  - name: total_birds_counted
+    data_type: bigint
+  - name: n_notable_observations
+    data_type: bigint
+
+  - name: nearest_station_id
+    data_type: text
+  - name: nearest_station_distance_miles
+    data_type: decimal
+  - name: tmax_c
+    data_type: decimal
+  - name: tmin_c
+    data_type: decimal
+  - name: temp_range_c
+    data_type: decimal
+  - name: prcp_mm
+    data_type: decimal
+  - name: snow_mm
+    data_type: decimal
+  - name: wind_ms
+    data_type: decimal
+  - name: is_rainy_day
+    data_type: boolean
+
+  - name: nearest_gauge_id
+    data_type: text
+  - name: nearest_gauge_distance_miles
+    data_type: decimal
+  - name: mean_discharge_cfs
+    data_type: decimal
+  - name: mean_gage_height_ft
+    data_type: decimal
+  - name: mean_water_temp_c
+    data_type: decimal
+
+  - name: cell_center_lat
+    data_type: double
+  - name: cell_center_lng
+    data_type: double
+
+  - name: ebird_last_loaded_at
+    data_type: timestamp
+  - name: noaa_last_loaded_at
+    data_type: timestamp
+  - name: usgs_last_loaded_at
+    data_type: timestamp
+  - name: last_updated_at
+    data_type: timestamp
+
+checks:
+  - duplicate:
+      columns: [species_code, h3_cell, obs_date]
+      must_be: 0
+  - row_count:
+      must_be_greater_than: 0

--- a/transforms/main/config.yaml
+++ b/transforms/main/config.yaml
@@ -2,6 +2,9 @@ gateways:
   local:
     connection:
       type: duckdb
+      extensions:
+        - name: h3
+          repository: community
       catalogs:
         databox: "{{ env_var('DUCKDB_PATH', 'data/databox.duckdb') }}"
         raw_ebird: "{{ env_var('RAW_EBIRD_PATH', 'data/raw_ebird.duckdb') }}"
@@ -11,6 +14,9 @@ gateways:
     connection:
       type: motherduck
       token: "{{ env_var('MOTHERDUCK_TOKEN', '') }}"
+      extensions:
+        - name: h3
+          repository: community
       catalogs:
         databox: "md:databox"
         raw_ebird: "md:raw_ebird"

--- a/transforms/main/models/analytics/fct_species_environment_daily.sql
+++ b/transforms/main/models/analytics/fct_species_environment_daily.sql
@@ -1,0 +1,95 @@
+MODEL (
+  name analytics.fct_species_environment_daily,
+  kind FULL,
+  description 'Flagship cross-domain mart: bird observations joined to daily weather and streamflow at species x H3 cell (resolution 6, ~36 km^2) x day grain. Answers questions like "which species show up on cold-snap days after heavy rainfall at this gauge." Grain is unique on (species_code, h3_cell, obs_date).',
+  grants (select_ = ['staging_reader', 'domain_reader', 'analyst'])
+);
+
+WITH obs AS (
+    SELECT
+        species_code,
+        common_name,
+        scientific_name,
+        h3_cell,
+        observation_date AS obs_date,
+        n_observations,
+        n_checklists,
+        total_birds_counted,
+        n_notable_observations,
+        last_loaded_at AS ebird_last_loaded_at
+    FROM ebird.int_observations_by_h3_day
+),
+
+weather AS (
+    SELECT
+        h3_cell,
+        observation_date,
+        nearest_station_id,
+        nearest_station_distance_miles,
+        tmax_c,
+        tmin_c,
+        prcp_mm,
+        snow_mm,
+        wind_ms,
+        last_loaded_at AS noaa_last_loaded_at
+    FROM noaa.int_weather_by_h3_day
+),
+
+streamflow AS (
+    SELECT
+        h3_cell,
+        observation_date,
+        nearest_gauge_id,
+        nearest_gauge_distance_miles,
+        mean_discharge_cfs,
+        mean_gage_height_ft,
+        mean_water_temp_c,
+        last_loaded_at AS usgs_last_loaded_at
+    FROM usgs.int_streamflow_by_h3_day
+)
+
+SELECT
+    o.species_code,
+    o.common_name,
+    o.scientific_name,
+    o.h3_cell,
+    o.obs_date,
+
+    o.n_observations,
+    o.n_checklists,
+    o.total_birds_counted,
+    o.n_notable_observations,
+
+    w.nearest_station_id,
+    ROUND(w.nearest_station_distance_miles::NUMERIC, 2)
+        AS nearest_station_distance_miles,
+    ROUND(w.tmax_c::NUMERIC, 1) AS tmax_c,
+    ROUND(w.tmin_c::NUMERIC, 1) AS tmin_c,
+    ROUND((w.tmax_c - w.tmin_c)::NUMERIC, 1) AS temp_range_c,
+    ROUND(w.prcp_mm::NUMERIC, 2) AS prcp_mm,
+    ROUND(w.snow_mm::NUMERIC, 2) AS snow_mm,
+    ROUND(w.wind_ms::NUMERIC, 2) AS wind_ms,
+    CASE WHEN w.prcp_mm > 0 THEN TRUE ELSE FALSE END AS is_rainy_day,
+
+    s.nearest_gauge_id,
+    ROUND(s.nearest_gauge_distance_miles::NUMERIC, 2)
+        AS nearest_gauge_distance_miles,
+    ROUND(s.mean_discharge_cfs::NUMERIC, 2) AS mean_discharge_cfs,
+    ROUND(s.mean_gage_height_ft::NUMERIC, 2) AS mean_gage_height_ft,
+    ROUND(s.mean_water_temp_c::NUMERIC, 2) AS mean_water_temp_c,
+
+    h3_cell_to_lat(o.h3_cell) AS cell_center_lat,
+    h3_cell_to_lng(o.h3_cell) AS cell_center_lng,
+
+    o.ebird_last_loaded_at,
+    w.noaa_last_loaded_at,
+    s.usgs_last_loaded_at,
+    CURRENT_TIMESTAMP AS last_updated_at
+
+FROM obs o
+LEFT JOIN weather w
+    ON w.h3_cell = o.h3_cell
+    AND w.observation_date = o.obs_date
+LEFT JOIN streamflow s
+    ON s.h3_cell = o.h3_cell
+    AND s.observation_date = o.obs_date

--- a/transforms/main/models/ebird/intermediate/int_observations_by_h3_day.sql
+++ b/transforms/main/models/ebird/intermediate/int_observations_by_h3_day.sql
@@ -1,0 +1,23 @@
+MODEL (
+  name ebird.int_observations_by_h3_day,
+  kind FULL,
+  description 'eBird observations rolled up to H3 cell x species x observation_date. H3 resolution 6 (~36 km^2 hex). Feeds analytics.fct_species_environment_daily.',
+  grants (select_ = ['staging_reader', 'domain_reader'])
+);
+
+SELECT
+    h3_latlng_to_cell_string(latitude, longitude, 6) AS h3_cell,
+    observation_date,
+    species_code,
+    ANY_VALUE(common_name) AS common_name,
+    ANY_VALUE(scientific_name) AS scientific_name,
+    COUNT(*) AS n_observations,
+    COUNT(DISTINCT submission_id) AS n_checklists,
+    SUM(count) AS total_birds_counted,
+    SUM(CASE WHEN is_notable THEN 1 ELSE 0 END) AS n_notable_observations,
+    MAX(loaded_at) AS last_loaded_at
+FROM ebird_staging.stg_ebird_observations
+WHERE latitude IS NOT NULL
+  AND longitude IS NOT NULL
+  AND observation_date IS NOT NULL
+GROUP BY h3_cell, observation_date, species_code

--- a/transforms/main/models/noaa/intermediate/int_weather_by_h3_day.sql
+++ b/transforms/main/models/noaa/intermediate/int_weather_by_h3_day.sql
@@ -1,0 +1,72 @@
+MODEL (
+  name noaa.int_weather_by_h3_day,
+  kind FULL,
+  description 'Daily NOAA weather assigned to each H3 cell in the bird-observation universe via nearest-station join. Station-to-cell mapping is computed once; daily values join in after. H3 resolution 6 matches ebird.int_observations_by_h3_day.',
+  grants (select_ = ['staging_reader', 'domain_reader'])
+);
+
+WITH cells AS (
+    SELECT DISTINCT h3_cell
+    FROM ebird.int_observations_by_h3_day
+),
+
+cell_centers AS (
+    SELECT
+        h3_cell,
+        h3_cell_to_lat(h3_cell) AS cell_lat,
+        h3_cell_to_lng(h3_cell) AS cell_lng
+    FROM cells
+),
+
+stations AS (
+    SELECT
+        station_id,
+        latitude,
+        longitude
+    FROM noaa_staging.stg_noaa_stations
+    WHERE latitude IS NOT NULL AND longitude IS NOT NULL
+),
+
+cell_station_distance AS (
+    SELECT
+        c.h3_cell,
+        s.station_id,
+        2 * 3959 * ASIN(SQRT(
+            POWER(SIN((RADIANS(c.cell_lat) - RADIANS(s.latitude)) / 2), 2)
+            + COS(RADIANS(c.cell_lat)) * COS(RADIANS(s.latitude))
+              * POWER(SIN((RADIANS(c.cell_lng) - RADIANS(s.longitude)) / 2), 2)
+        )) AS distance_miles
+    FROM cell_centers c
+    CROSS JOIN stations s
+),
+
+nearest_station AS (
+    SELECT
+        h3_cell,
+        station_id AS nearest_station_id,
+        distance_miles AS nearest_station_distance_miles
+    FROM (
+        SELECT
+            h3_cell,
+            station_id,
+            distance_miles,
+            ROW_NUMBER() OVER (PARTITION BY h3_cell ORDER BY distance_miles) AS rn
+        FROM cell_station_distance
+    )
+    WHERE rn = 1
+)
+
+SELECT
+    ns.h3_cell,
+    fw.observation_date,
+    ns.nearest_station_id,
+    ns.nearest_station_distance_miles,
+    fw.tmax / 10.0 AS tmax_c,
+    fw.tmin / 10.0 AS tmin_c,
+    fw.prcp / 10.0 AS prcp_mm,
+    fw.snow AS snow_mm,
+    fw.awnd / 10.0 AS wind_ms,
+    fw.last_loaded_at
+FROM nearest_station ns
+JOIN noaa.fct_daily_weather fw
+    ON fw.station = ns.nearest_station_id

--- a/transforms/main/models/usgs/intermediate/int_streamflow_by_h3_day.sql
+++ b/transforms/main/models/usgs/intermediate/int_streamflow_by_h3_day.sql
@@ -1,0 +1,70 @@
+MODEL (
+  name usgs.int_streamflow_by_h3_day,
+  kind FULL,
+  description 'Daily USGS streamflow assigned to each H3 cell in the bird-observation universe via nearest-gauge join. Cell-to-gauge mapping is computed once; daily values join in after. H3 resolution 6 matches ebird.int_observations_by_h3_day.',
+  grants (select_ = ['staging_reader', 'domain_reader'])
+);
+
+WITH cells AS (
+    SELECT DISTINCT h3_cell
+    FROM ebird.int_observations_by_h3_day
+),
+
+cell_centers AS (
+    SELECT
+        h3_cell,
+        h3_cell_to_lat(h3_cell) AS cell_lat,
+        h3_cell_to_lng(h3_cell) AS cell_lng
+    FROM cells
+),
+
+gauges AS (
+    SELECT DISTINCT
+        site_no,
+        latitude,
+        longitude
+    FROM usgs_staging.stg_usgs_sites
+    WHERE latitude IS NOT NULL AND longitude IS NOT NULL
+),
+
+cell_gauge_distance AS (
+    SELECT
+        c.h3_cell,
+        g.site_no,
+        2 * 3959 * ASIN(SQRT(
+            POWER(SIN((RADIANS(c.cell_lat) - RADIANS(g.latitude)) / 2), 2)
+            + COS(RADIANS(c.cell_lat)) * COS(RADIANS(g.latitude))
+              * POWER(SIN((RADIANS(c.cell_lng) - RADIANS(g.longitude)) / 2), 2)
+        )) AS distance_miles
+    FROM cell_centers c
+    CROSS JOIN gauges g
+),
+
+nearest_gauge AS (
+    SELECT
+        h3_cell,
+        site_no AS nearest_gauge_id,
+        distance_miles AS nearest_gauge_distance_miles
+    FROM (
+        SELECT
+            h3_cell,
+            site_no,
+            distance_miles,
+            ROW_NUMBER() OVER (PARTITION BY h3_cell ORDER BY distance_miles) AS rn
+        FROM cell_gauge_distance
+    )
+    WHERE rn = 1
+)
+
+SELECT
+    ng.h3_cell,
+    fs.observation_date,
+    ng.nearest_gauge_id,
+    ng.nearest_gauge_distance_miles,
+    fs.discharge_cfs AS mean_discharge_cfs,
+    fs.gage_height_ft AS mean_gage_height_ft,
+    fs.water_temp_c AS mean_water_temp_c,
+    fs.last_loaded_at
+FROM nearest_gauge ng
+JOIN usgs.fct_daily_streamflow fs
+    ON fs.site_no = ng.nearest_gauge_id


### PR DESCRIPTION
## Summary
- Build `analytics.fct_species_environment_daily` joining eBird + NOAA + USGS at **species × H3 cell (res 6, ~36 km² hex) × day** grain
- H3 community extension wired into SQLMesh config (both local + motherduck gateways)
- Three new intermediate models assign environmental values to each H3 cell via **nearest-station / nearest-gauge haversine join**, then the mart LEFT-joins on `(h3_cell, obs_date)`
- Soda contract + Dagster asset check; mart is unique on `(species_code, h3_cell, obs_date)`
- `docs/analytics-examples.md` with four example queries (cold+rainy species, diversity hotspots, streamflow regime, cold-snap-after-rainfall)

## Test plan
- [x] `sqlmesh plan prod --auto-apply` applies cleanly with 20 models materialized
- [x] Mart produces 2275 rows across 363 species, 395 H3 cells, 31 days on current data snapshot
- [x] Zero duplicates on `(species_code, h3_cell, obs_date)`
- [x] Soda contract: 6 checks, 6 passed, 0 failed
- [x] `sqlmesh evaluate` re-runs deterministically (idempotent)
- [x] Full pytest suite: 26 passed
- [x] `ruff check`, `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)