### PR TITLE
feat(analytics): semantic metrics layer on flagship mart

### DIFF
--- a/.loom/research/20260421-semantic-metrics-approach.md
+++ b/.loom/research/20260421-semantic-metrics-approach.md
@@ -1,0 +1,96 @@
+---
+id: research:semantic-metrics-approach
+kind: research
+status: active
+created_at: 2026-04-21T00:00:00Z
+updated_at: 2026-04-21T00:00:00Z
+scope:
+  kind: repository
+  repositories:
+    - repo:root
+links:
+  ticket: ticket:semantic-metrics-layer
+  plan: plan:staff-portfolio-readiness
+---
+
+# Question
+
+Which semantic/metrics layer approach best fits a single-operator, zero-cost
+data platform whose constitution favors "fewer, stronger tools"? Candidates:
+
+1. **SQLMesh native `METRIC()` DDL** — built into the transformation engine
+   already in the stack (v0.234.1).
+2. **MetricFlow standalone** — dbt Labs' semantic layer, operable outside dbt.
+3. **Flat `analytics.metric_*` views** — one SQLMesh view per metric, no
+   additional tooling.
+
+# Decision
+
+**Adopt SQLMesh native `METRIC()` DDL.** The metrics live in
+`transforms/main/metrics/flagship.sql` and consumers resolve them via a thin
+Python helper (`databox_orchestration.metrics.resolve_metric_query`) that
+wraps SQLMesh's metric rewriter.
+
+# Evaluation
+
+## SQLMesh `METRIC()` (chosen)
+
+- Lives inside the existing SQLMesh project — zero new dependencies, no
+  second config surface.
+- Supports derived metrics (e.g. `observation_intensity = total_observations
+  / NULLIF(total_checklists, 0)`); the rewriter auto-hoists the raw
+  aggregates the derived metric needs, so consumers just ask for the
+  derived name.
+- Requires model `grain` to be declared on the underlying mart — already
+  aligned with our flagship mart's uniqueness key
+  `(species_code, h3_cell, obs_date)`.
+- Caveat: the documented `SELECT METRIC(...) FROM __semantic.__table`
+  syntax is **not** automatically expanded inside model query bodies in
+  v0.234.1. The rewriter must be invoked explicitly (see
+  `sqlmesh.core.metric.rewriter.rewrite`). Acceptable trade — we wrap it in
+  `resolve_metric_query()` and consumers call that function; they never
+  see the raw rewriter.
+- Caveat: aggregate expressions must reference a single measure column
+  (e.g. `AVG(t.col)`) — wrapping `CASE WHEN` directly inside the aggregate
+  trips "Could not infer a measures table from..." We work around this by
+  adding precomputed `is_hot_day` column to the mart rather than computing
+  it inside the metric expression.
+
+## MetricFlow standalone (rejected)
+
+- Powerful semantic model (entities, dimensions, measures, time grains)
+  but requires its own YAML dialect, Python runtime, and server process
+  for query resolution.
+- Project-level overhead is disproportionate for a single flagship mart
+  with seven metrics.
+- Violates constitution principle #4 ("fewer, stronger tools"): adds a new
+  tool with significant conceptual footprint alongside SQLMesh.
+
+## Flat `analytics.metric_*` views (rejected)
+
+- Cheapest in tooling: one view per metric, zero new abstractions.
+- No first-class notion of a "metric"; consumers would still have to
+  remember which view computes what. Derived metrics (e.g. ratios) would
+  duplicate SQL across views.
+- Signals lack of awareness of the metric-sprawl problem the ticket is
+  designed to address.
+
+# Consequences
+
+- Metric definitions live in one place (`transforms/main/metrics/flagship.sql`).
+- Consumers (Dagster, notebooks, Streamlit) import
+  `databox_orchestration.metrics.resolve_metric_query`, pass a query using
+  `METRIC(...)` syntax, and receive executable SQL.
+- Adding a new metric = add a `METRIC (...)` block + list it in
+  `docs/metrics.md`. No new models, no new consumers to update.
+- The `is_hot_day` flag on the flagship mart is load-bearing for the
+  `heat_stress_index` metric; removing it would break metric resolution.
+
+# References
+
+- SQLMesh metrics docs:
+  https://sqlmesh.readthedocs.io/en/stable/concepts/metrics/overview/
+- SQLMesh metrics definition:
+  https://sqlmesh.readthedocs.io/en/stable/concepts/metrics/definition/
+- Internal: `packages/databox-orchestration/databox_orchestration/metrics.py`
+- Internal: `tests/test_metrics.py`

--- a/README.md
+++ b/README.md
@@ -171,6 +171,12 @@ queries against the flagship cross-domain mart
 (`analytics.fct_species_environment_daily`) that joins eBird observations
 with NOAA weather and USGS streamflow at species × H3 cell × day grain.
 
+See [docs/metrics.md](docs/metrics.md) for the semantic metrics layer —
+seven metrics (species richness, observation intensity, heat-stress index,
+rainfall/discharge anomaly z-scores, raw observation/checklist counts)
+defined once in SQLMesh and queryable by name via
+`databox_orchestration.metrics.resolve_metric_query`.
+
 ## License
 
 MIT

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,91 @@
+# Semantic Metrics
+
+Canonical metric definitions over `analytics.fct_species_environment_daily`.
+Every metric below is registered in
+[`transforms/main/metrics/flagship.sql`](../transforms/main/metrics/flagship.sql)
+and is the single source of truth — if you see metric math duplicated
+elsewhere, that duplication is a bug.
+
+## Registry
+
+| Metric | Grain | Units | Definition |
+|---|---|---|---|
+| `species_richness` | any group | count | Distinct `species_code` in the group. |
+| `total_observations` | any group | count | `SUM(n_observations)`. |
+| `total_checklists` | any group | count | `SUM(n_checklists)`. |
+| `observation_intensity` | any group | ratio | `total_observations / NULLIF(total_checklists, 0)`. Higher = more observations per checklist; a proxy for species density. |
+| `heat_stress_index` | any group | 0–1 fraction | Fraction of grouped rows where `tmax_c >= 30`. Backed by the precomputed `is_hot_day` column on the mart. |
+| `rainfall_anomaly_7d` | any group | z-score | Mean 7-day precipitation z-score (`(prcp - μ₇) / σ₇` per `(h3_cell, obs_date)`). Positive = wetter than local recent average. Null when the 7-day window has zero variance. |
+| `discharge_anomaly_7d` | any group | z-score | Mean 7-day streamflow z-score (`(discharge - μ₇) / σ₇` per `(h3_cell, obs_date)`). Positive = higher flow than local recent average. |
+
+"Any group" means the metric is well-defined for any `GROUP BY` the mart
+supports — typically `obs_date`, `h3_cell`, `species_code`, or a
+combination.
+
+## Caveats
+
+- **Data latency.** NOAA GHCND publishes daily weather on a 3–7 day lag; on
+  any given recent date the weather/anomaly metrics are sparse (~22% of
+  rows on a 30-day window). USGS streamflow is faster (~85%). Bird
+  observations are same-day.
+- **Anomaly warm-up.** `rainfall_anomaly_7d` and `discharge_anomaly_7d`
+  require 7 days of history per cell before producing a value. On a fresh
+  30-day window, expect the first ~6 days per cell to be null.
+- **Zero-variance windows.** When the 7-day window has identical values
+  (σ = 0), the anomaly z-score is null rather than infinite.
+
+## Usage
+
+Consumers request metrics by name, not by copy-pasted SQL.
+
+### Python
+
+```python
+from databox_orchestration.metrics import resolve_metric_query
+
+sql = resolve_metric_query(
+    """
+    SELECT obs_date,
+           METRIC(species_richness) AS species_richness,
+           METRIC(observation_intensity) AS observation_intensity,
+           METRIC(heat_stress_index) AS heat_stress_index
+    FROM __semantic.__table
+    GROUP BY obs_date
+    ORDER BY obs_date
+    """
+)
+# `sql` is DuckDB-ready SQL against analytics.fct_species_environment_daily.
+# Execute it via duckdb, motherduck, or any sqlmesh gateway.
+```
+
+### Listing available metrics
+
+```python
+from databox_orchestration.metrics import available_metrics
+print(available_metrics())
+# -> ['discharge_anomaly_7d', 'heat_stress_index', 'observation_intensity',
+#     'rainfall_anomaly_7d', 'species_richness', 'total_checklists',
+#     'total_observations']
+```
+
+## Adding a New Metric
+
+1. Add a `METRIC (name=..., expression=...)` block to
+   `transforms/main/metrics/flagship.sql`.
+2. Fully qualify column references:
+   `analytics.fct_species_environment_daily.<col>`.
+3. If the metric needs a non-trivial per-row derivation (e.g. a `CASE`
+   expression), precompute it as a column on the flagship mart — the
+   SQLMesh rewriter expects `AGG(table.col)` shape, not
+   `AGG(CASE WHEN ...)`.
+4. Add the metric name to `REQUIRED_METRICS` in `tests/test_metrics.py`
+   if it's ticket-level required.
+5. Document the new metric in the registry table above.
+6. Run `uv run pytest tests/test_metrics.py`.
+
+## Design Decision
+
+See
+[`.loom/research/20260421-semantic-metrics-approach.md`](../.loom/research/20260421-semantic-metrics-approach.md)
+for why SQLMesh native metrics beat MetricFlow and flat `analytics.metric_*`
+views for this project.

--- a/packages/databox-orchestration/databox_orchestration/metrics.py
+++ b/packages/databox-orchestration/databox_orchestration/metrics.py
@@ -1,0 +1,59 @@
+"""Semantic metrics layer — resolve metric queries against the flagship mart.
+
+Consumers request metrics by name (e.g. ``METRIC(species_richness)``) via the
+special ``__semantic.__table`` placeholder; this module rewrites those queries
+into executable SQL against the actual mart using SQLMesh's metric rewriter.
+
+Example:
+
+    from databox_orchestration.metrics import resolve_metric_query
+
+    sql = resolve_metric_query(
+        "SELECT obs_date, METRIC(species_richness) AS sr "
+        "FROM __semantic.__table GROUP BY obs_date"
+    )
+    # -> ready-to-execute DuckDB SQL against analytics.fct_species_environment_daily
+
+The single source of truth for metric definitions is
+``transforms/main/metrics/flagship.sql``. If a metric changes there,
+all consumers see the new definition immediately.
+"""
+
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from pathlib import Path
+
+from sqlmesh import Context
+from sqlmesh.core.metric.rewriter import rewrite as _metric_rewrite
+from sqlmesh.core.reference import ReferenceGraph
+
+TRANSFORMS_PATH = Path(__file__).resolve().parents[3] / "transforms" / "main"
+
+
+@lru_cache(maxsize=1)
+def _context() -> Context:
+    return Context(
+        paths=[str(TRANSFORMS_PATH)],
+        gateway=os.environ.get("DATABOX_GATEWAY", "local"),
+    )
+
+
+def available_metrics() -> list[str]:
+    """Return the list of registered metric names."""
+    return sorted(_context()._metrics.keys())
+
+
+def resolve_metric_query(sql: str, dialect: str = "duckdb") -> str:
+    """Rewrite a metric-aware query into executable SQL.
+
+    The query should reference metrics via ``METRIC(<name>)`` and select from
+    ``__semantic.__table``. The rewriter replaces the placeholder with the
+    underlying mart and expands each ``METRIC(...)`` into its registered SQL
+    expression.
+    """
+    ctx = _context()
+    graph = ReferenceGraph(ctx._models.values())
+    rewritten = _metric_rewrite(sql, graph=graph, metrics=ctx._metrics, dialect=dialect)
+    return rewritten.sql(dialect=dialect)

--- a/soda/contracts/analytics/fct_species_environment_daily.yaml
+++ b/soda/contracts/analytics/fct_species_environment_daily.yaml
@@ -51,6 +51,8 @@ columns:
     data_type: decimal
   - name: is_rainy_day
     data_type: boolean
+  - name: is_hot_day
+    data_type: bigint
 
   - name: nearest_gauge_id
     data_type: text
@@ -61,6 +63,11 @@ columns:
   - name: mean_gage_height_ft
     data_type: decimal
   - name: mean_water_temp_c
+    data_type: decimal
+
+  - name: prcp_mm_z_7d
+    data_type: decimal
+  - name: discharge_cfs_z_7d
     data_type: decimal
 
   - name: cell_center_lat

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,75 @@
+"""Semantic metrics layer tests.
+
+Validates that the SQLMesh metric registry loads without errors, every
+ticket-required metric is present, and each metric rewrites into syntactically
+valid SQL that references the flagship mart.
+
+Does not hit the live database — these are registry/structure tests. Live
+verification runs as the Dagster asset check on the flagship mart.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+REQUIRED_METRICS = {
+    "species_richness",
+    "observation_intensity",
+    "heat_stress_index",
+    "rainfall_anomaly_7d",
+    "discharge_anomaly_7d",
+}
+
+
+@pytest.fixture(scope="module")
+def metrics_context():
+    from databox_orchestration.metrics import _context
+
+    return _context()
+
+
+def test_required_metrics_registered(metrics_context) -> None:
+    """Every metric named in the ticket must exist in the registry."""
+    loaded = set(metrics_context._metrics.keys())
+    missing = REQUIRED_METRICS - loaded
+    assert not missing, f"Missing required metrics: {sorted(missing)}"
+
+
+def test_metric_query_rewrites_to_valid_sql() -> None:
+    """A simple METRIC() query must rewrite into SQL that parses and names the flagship mart."""
+    from databox_orchestration.metrics import resolve_metric_query
+
+    sql = resolve_metric_query(
+        "SELECT obs_date, METRIC(species_richness) AS sr FROM __semantic.__table GROUP BY obs_date"
+    )
+    assert "analytics.fct_species_environment_daily" in sql
+    assert "COUNT(DISTINCT" in sql
+    assert "__semantic" not in sql
+
+
+def test_derived_metric_expands_dependencies() -> None:
+    """observation_intensity = total_observations / total_checklists.
+
+    Both raw aggregates must appear in the rewritten SQL.
+    """
+    from databox_orchestration.metrics import resolve_metric_query
+
+    sql = resolve_metric_query(
+        "SELECT obs_date, METRIC(observation_intensity) AS oi "
+        "FROM __semantic.__table GROUP BY obs_date"
+    )
+    assert "SUM(" in sql
+    assert "n_observations" in sql
+    assert "n_checklists" in sql
+    assert "NULLIF" in sql
+
+
+def test_all_ticket_metrics_resolve() -> None:
+    """Every required metric must rewrite without error."""
+    from databox_orchestration.metrics import resolve_metric_query
+
+    for metric in REQUIRED_METRICS:
+        sql = resolve_metric_query(
+            f"SELECT obs_date, METRIC({metric}) AS v FROM __semantic.__table GROUP BY obs_date"
+        )
+        assert "analytics.fct_species_environment_daily" in sql, f"{metric} did not bind to mart"

--- a/transforms/main/metrics/flagship.sql
+++ b/transforms/main/metrics/flagship.sql
@@ -1,0 +1,45 @@
+-- Semantic metrics over analytics.fct_species_environment_daily.
+-- All metrics are defined against the flagship mart's grain
+-- (species_code, h3_cell, obs_date).
+
+METRIC (
+  name species_richness,
+  description 'Distinct species count. Grouping by (h3_cell, obs_date) gives per-cell-day diversity; grouping by obs_date gives platform-wide daily diversity.',
+  expression COUNT(DISTINCT analytics.fct_species_environment_daily.species_code)
+);
+
+METRIC (
+  name total_observations,
+  description 'Sum of eBird observations recorded (one per species-hotspot-date entry).',
+  expression SUM(analytics.fct_species_environment_daily.n_observations)
+);
+
+METRIC (
+  name total_checklists,
+  description 'Sum of eBird checklists covering the grouped slice.',
+  expression SUM(analytics.fct_species_environment_daily.n_checklists)
+);
+
+METRIC (
+  name observation_intensity,
+  description 'Average observations per checklist. Derived from total_observations / total_checklists.',
+  expression total_observations / NULLIF(total_checklists, 0)
+);
+
+METRIC (
+  name heat_stress_index,
+  description 'Fraction of grouped rows where tmax >= 30C (uses the precomputed is_hot_day flag on the flagship mart). Grouped by species reveals heat-tolerant species.',
+  expression AVG(analytics.fct_species_environment_daily.is_hot_day)
+);
+
+METRIC (
+  name rainfall_anomaly_7d,
+  description 'Mean 7-day precipitation z-score across grouped rows. Positive = wetter than local recent average; negative = drier. Null when the 7-day window has zero stddev (uniform precipitation).',
+  expression AVG(analytics.fct_species_environment_daily.prcp_mm_z_7d)
+);
+
+METRIC (
+  name discharge_anomaly_7d,
+  description 'Mean 7-day streamflow z-score across grouped rows. Positive = higher than local recent average (e.g. post-rainfall surge); negative = lower.',
+  expression AVG(analytics.fct_species_environment_daily.discharge_cfs_z_7d)
+);

--- a/transforms/main/models/analytics/fct_species_environment_daily.sql
+++ b/transforms/main/models/analytics/fct_species_environment_daily.sql
@@ -2,6 +2,7 @@ MODEL (
   name analytics.fct_species_environment_daily,
   kind FULL,
   description 'Flagship cross-domain mart: bird observations joined to daily weather and streamflow at species x H3 cell (resolution 6, ~36 km^2) x day grain. Answers questions like "which species show up on cold-snap days after heavy rainfall at this gauge." Grain is unique on (species_code, h3_cell, obs_date).',
+  grain (species_code, h3_cell, obs_date),
   grants (select_ = ['staging_reader', 'domain_reader', 'analyst'])
 );
 
@@ -46,6 +47,42 @@ streamflow AS (
         mean_water_temp_c,
         last_loaded_at AS usgs_last_loaded_at
     FROM usgs.int_streamflow_by_h3_day
+),
+
+weather_anomaly AS (
+    SELECT
+        h3_cell,
+        observation_date,
+        prcp_mm,
+        AVG(prcp_mm) OVER (
+            PARTITION BY h3_cell
+            ORDER BY observation_date
+            ROWS BETWEEN 6 PRECEDING AND CURRENT ROW
+        ) AS prcp_mm_7d_mean,
+        STDDEV_SAMP(prcp_mm) OVER (
+            PARTITION BY h3_cell
+            ORDER BY observation_date
+            ROWS BETWEEN 6 PRECEDING AND CURRENT ROW
+        ) AS prcp_mm_7d_stddev
+    FROM weather
+),
+
+streamflow_anomaly AS (
+    SELECT
+        h3_cell,
+        observation_date,
+        mean_discharge_cfs,
+        AVG(mean_discharge_cfs) OVER (
+            PARTITION BY h3_cell
+            ORDER BY observation_date
+            ROWS BETWEEN 6 PRECEDING AND CURRENT ROW
+        ) AS discharge_cfs_7d_mean,
+        STDDEV_SAMP(mean_discharge_cfs) OVER (
+            PARTITION BY h3_cell
+            ORDER BY observation_date
+            ROWS BETWEEN 6 PRECEDING AND CURRENT ROW
+        ) AS discharge_cfs_7d_stddev
+    FROM streamflow
 )
 
 SELECT
@@ -70,6 +107,7 @@ SELECT
     ROUND(w.snow_mm::NUMERIC, 2) AS snow_mm,
     ROUND(w.wind_ms::NUMERIC, 2) AS wind_ms,
     CASE WHEN w.prcp_mm > 0 THEN TRUE ELSE FALSE END AS is_rainy_day,
+    CASE WHEN w.tmax_c >= 30 THEN 1 ELSE 0 END AS is_hot_day,
 
     s.nearest_gauge_id,
     ROUND(s.nearest_gauge_distance_miles::NUMERIC, 2)
@@ -77,6 +115,21 @@ SELECT
     ROUND(s.mean_discharge_cfs::NUMERIC, 2) AS mean_discharge_cfs,
     ROUND(s.mean_gage_height_ft::NUMERIC, 2) AS mean_gage_height_ft,
     ROUND(s.mean_water_temp_c::NUMERIC, 2) AS mean_water_temp_c,
+
+    ROUND(
+        CASE
+            WHEN wa.prcp_mm_7d_stddev IS NULL OR wa.prcp_mm_7d_stddev = 0 THEN NULL
+            ELSE (wa.prcp_mm - wa.prcp_mm_7d_mean) / wa.prcp_mm_7d_stddev
+        END::NUMERIC,
+        3
+    ) AS prcp_mm_z_7d,
+    ROUND(
+        CASE
+            WHEN sa.discharge_cfs_7d_stddev IS NULL OR sa.discharge_cfs_7d_stddev = 0 THEN NULL
+            ELSE (sa.mean_discharge_cfs - sa.discharge_cfs_7d_mean) / sa.discharge_cfs_7d_stddev
+        END::NUMERIC,
+        3
+    ) AS discharge_cfs_z_7d,
 
     h3_cell_to_lat(o.h3_cell) AS cell_center_lat,
     h3_cell_to_lng(o.h3_cell) AS cell_center_lng,
@@ -93,3 +146,9 @@ LEFT JOIN weather w
 LEFT JOIN streamflow s
     ON s.h3_cell = o.h3_cell
     AND s.observation_date = o.obs_date
+LEFT JOIN weather_anomaly wa
+    ON wa.h3_cell = o.h3_cell
+    AND wa.observation_date = o.obs_date
+LEFT JOIN streamflow_anomaly sa
+    ON sa.h3_cell = o.h3_cell
+    AND sa.observation_date = o.obs_date


### PR DESCRIPTION
## Summary
- Ship **seven canonical metrics** defined once in `transforms/main/metrics/flagship.sql` and resolvable by name via `databox_orchestration.metrics.resolve_metric_query()`: `species_richness`, `total_observations`, `total_checklists`, `observation_intensity` (derived), `heat_stress_index`, `rainfall_anomaly_7d`, `discharge_anomaly_7d`.
- Flagship mart gets `grain (species_code, h3_cell, obs_date)` plus three additive columns (`is_hot_day`, `prcp_mm_z_7d`, `discharge_cfs_z_7d`) backing derived/anomaly metrics. SQLMesh classifies the change as **non-breaking**.
- Research record `.loom/research/20260421-semantic-metrics-approach.md` captures why SQLMesh native `METRIC()` beat MetricFlow and flat `analytics.metric_*` views for this project.
- Docs: `docs/metrics.md` (registry + usage), plus README link.

## Approach
- SQLMesh metrics are defined declaratively in `transforms/main/metrics/flagship.sql`.
- The documented `SELECT METRIC(...) FROM __semantic.__table` syntax is **not** auto-rewritten inside model bodies in SQLMesh v0.234.1 — we invoke the rewriter explicitly via `sqlmesh.core.metric.rewriter.rewrite` and expose it through `resolve_metric_query()`. Consumers pass in metric-aware SQL and get DuckDB-executable SQL back.
- Aggregate expressions must reference a single measure column, so `heat_stress_index` is backed by a precomputed `is_hot_day` flag on the mart rather than wrapping `CASE WHEN` inside `AVG()`.

## Test plan
- [x] `tests/test_metrics.py` — 4 tests covering registry presence, rewrite correctness, derived-metric expansion, and per-metric resolution for all five ticket-required metrics
- [x] Full suite: 30 passed
- [x] `sqlmesh plan prod --auto-apply` applies cleanly, mart rebuilt
- [x] Soda contract on flagship mart: 6/6 checks pass
- [x] End-to-end smoke: resolved `METRIC(species_richness)` + `METRIC(observation_intensity)` SQL executed against prod mart on MotherDuck returns sensible values (13 species on day 1 → 58 mid-window; intensity ≈ 1.0)
- [x] `ruff check`, `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)