### PR TITLE
feat(docs): auto-generated data dictionary + MkDocs site

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,54 @@
+name: Docs
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: docs-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    name: Build data-dictionary site
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - name: Install
+        run: uv sync --all-extras --dev
+      - name: Generate data dictionary
+        env:
+          DATABOX_GATEWAY: local
+        run: uv run python scripts/generate_docs.py
+      - name: Build MkDocs site
+        run: uv run mkdocs build --strict
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa  # v3.0.1
+        with:
+          path: site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e  # v4.0.5

--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ j_state/
 
 # Loom
 .loom/memory/user
+
+# MkDocs build output
+site/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+        exclude: ^mkdocs\.yml$
       - id: check-added-large-files
       - id: check-json
       - id: check-toml

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ defined once in SQLMesh and queryable by name via
 ## Data dictionary
 
 Auto-generated data dictionary + lineage site published via GitHub Pages:
-**https://crlough.github.io/databox/**
+**https://doctacon.github.io/databox/**
 
 Every SQLMesh model has a page listing its columns, types, Soda-contract
 checks, and direct upstream/downstream dependencies. A global Mermaid

--- a/README.md
+++ b/README.md
@@ -177,6 +177,23 @@ rainfall/discharge anomaly z-scores, raw observation/checklist counts)
 defined once in SQLMesh and queryable by name via
 `databox_orchestration.metrics.resolve_metric_query`.
 
+## Data dictionary
+
+Auto-generated data dictionary + lineage site published via GitHub Pages:
+**https://crlough.github.io/databox/**
+
+Every SQLMesh model has a page listing its columns, types, Soda-contract
+checks, and direct upstream/downstream dependencies. A global Mermaid
+lineage graph links every node back to its page. Regenerate locally with:
+
+```bash
+uv run python scripts/generate_docs.py
+uv run mkdocs serve   # live preview at localhost:8000
+```
+
+The `.github/workflows/docs.yaml` workflow rebuilds and deploys on every
+push to `main`.
+
 ## License
 
 MIT

--- a/docs/dictionary/analytics/fct_bird_weather_daily.md
+++ b/docs/dictionary/analytics/fct_bird_weather_daily.md
@@ -1,0 +1,63 @@
+# analytics.fct_bird_weather_daily
+
+eBird daily observations joined with NOAA weather conditions — one row per region x date x species
+
+## Overview
+
+| Field | Value |
+| --- | --- |
+| Schema | `analytics` |
+| Name | `fct_bird_weather_daily` |
+| Kind | `FULL` |
+| Soda contract | [`soda/contracts/analytics/fct_bird_weather_daily.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/analytics/fct_bird_weather_daily.yaml) |
+
+## Columns
+
+| Column | Type | Checks | Notes |
+| --- | --- | --- | --- |
+| `avg_flock_size` | `DOUBLE` | — | — |
+| `avg_prcp_mm` | `DOUBLE` | — | — |
+| `avg_snow_mm` | `DOUBLE` | — | — |
+| `avg_tmax_c` | `DOUBLE` | — | — |
+| `avg_tmin_c` | `DOUBLE` | — | — |
+| `avg_wind_ms` | `DOUBLE` | — | — |
+| `common_name` | `UNKNOWN` | missing (must_be=0) | — |
+| `daily_temp_range_c` | `DOUBLE` | — | — |
+| `family_common_name` | `UNKNOWN` | — | — |
+| `is_rainy_day` | `BOOLEAN` | — | — |
+| `last_updated_at` | `TIMESTAMP` | — | — |
+| `location_count` | `BIGINT` | — | — |
+| `notable_observations` | `BIGINT` | — | — |
+| `observation_count` | `BIGINT` | missing (must_be=0) | — |
+| `observation_date` | `UNKNOWN` | missing (must_be=0) | — |
+| `popularity_score` | `DOUBLE` | — | — |
+| `region_code` | `UNKNOWN` | missing (must_be=0) | — |
+| `scientific_name` | `UNKNOWN` | — | — |
+| `season` | `TEXT` | — | — |
+| `species_code` | `UNKNOWN` | missing (must_be=0) | — |
+| `submission_count` | `BIGINT` | — | — |
+| `taxonomic_category` | `UNKNOWN` | — | — |
+| `total_birds_counted` | `UNKNOWN` | — | — |
+| `weather_station_count` | `BIGINT` | — | — |
+
+## Table-level checks
+
+- **row_count** — must_be_greater_than=0
+- **freshness** — column=last_updated_at, threshold={'unit': 'hour', 'must_be_less_than': 25}
+
+## Lineage
+
+**Upstream**
+
+- [`ebird.fct_daily_bird_observations`](../ebird/fct_daily_bird_observations.md)
+- [`noaa.fct_daily_weather`](../noaa/fct_daily_weather.md)
+
+**Downstream**
+
+- [`analytics.fct_species_weather_preferences`](fct_species_weather_preferences.md)
+
+## Example query
+
+```sql
+SELECT * FROM analytics.fct_bird_weather_daily LIMIT 100;
+```

--- a/docs/dictionary/analytics/fct_bird_weather_daily.md
+++ b/docs/dictionary/analytics/fct_bird_weather_daily.md
@@ -9,7 +9,7 @@ eBird daily observations joined with NOAA weather conditions — one row per reg
 | Schema | `analytics` |
 | Name | `fct_bird_weather_daily` |
 | Kind | `FULL` |
-| Soda contract | [`soda/contracts/analytics/fct_bird_weather_daily.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/analytics/fct_bird_weather_daily.yaml) |
+| Soda contract | [`soda/contracts/analytics/fct_bird_weather_daily.yaml`](https://github.com/Doctacon/databox/blob/main/soda/contracts/analytics/fct_bird_weather_daily.yaml) |
 
 ## Columns
 

--- a/docs/dictionary/analytics/fct_species_environment_daily.md
+++ b/docs/dictionary/analytics/fct_species_environment_daily.md
@@ -10,7 +10,7 @@ Flagship cross-domain mart: bird observations joined to daily weather and stream
 | Name | `fct_species_environment_daily` |
 | Kind | `FULL` |
 | Grain | `(species_code, h3_cell, obs_date)` |
-| Soda contract | [`soda/contracts/analytics/fct_species_environment_daily.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/analytics/fct_species_environment_daily.yaml) |
+| Soda contract | [`soda/contracts/analytics/fct_species_environment_daily.yaml`](https://github.com/Doctacon/databox/blob/main/soda/contracts/analytics/fct_species_environment_daily.yaml) |
 
 ## Columns
 

--- a/docs/dictionary/analytics/fct_species_environment_daily.md
+++ b/docs/dictionary/analytics/fct_species_environment_daily.md
@@ -1,0 +1,69 @@
+# analytics.fct_species_environment_daily
+
+Flagship cross-domain mart: bird observations joined to daily weather and streamflow at species x H3 cell (resolution 6, ~36 km^2) x day grain. Answers questions like "which species show up on cold-snap days after heavy rainfall at this gauge." Grain is unique on (species_code, h3_cell, obs_date).
+
+## Overview
+
+| Field | Value |
+| --- | --- |
+| Schema | `analytics` |
+| Name | `fct_species_environment_daily` |
+| Kind | `FULL` |
+| Grain | `(species_code, h3_cell, obs_date)` |
+| Soda contract | [`soda/contracts/analytics/fct_species_environment_daily.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/analytics/fct_species_environment_daily.yaml) |
+
+## Columns
+
+| Column | Type | Checks | Notes |
+| --- | --- | --- | --- |
+| `cell_center_lat` | `double` | — | — |
+| `cell_center_lng` | `double` | — | — |
+| `common_name` | `text` | — | — |
+| `discharge_cfs_z_7d` | `DOUBLE` | — | — |
+| `ebird_last_loaded_at` | `timestamp` | — | — |
+| `h3_cell` | `text` | missing (must_be=0) | — |
+| `is_hot_day` | `INT` | — | — |
+| `is_rainy_day` | `BOOLEAN` | — | — |
+| `last_updated_at` | `TIMESTAMP` | — | — |
+| `mean_discharge_cfs` | `DOUBLE` | — | — |
+| `mean_gage_height_ft` | `DOUBLE` | — | — |
+| `mean_water_temp_c` | `DOUBLE` | — | — |
+| `n_checklists` | `BIGINT` | — | — |
+| `n_notable_observations` | `BIGINT` | — | — |
+| `n_observations` | `BIGINT` | missing (must_be=0) | — |
+| `nearest_gauge_distance_miles` | `DOUBLE` | — | — |
+| `nearest_gauge_id` | `text` | — | — |
+| `nearest_station_distance_miles` | `DOUBLE` | — | — |
+| `nearest_station_id` | `text` | — | — |
+| `noaa_last_loaded_at` | `TIMESTAMP` | — | — |
+| `obs_date` | `date` | missing (must_be=0) | — |
+| `prcp_mm` | `DOUBLE` | — | — |
+| `prcp_mm_z_7d` | `DOUBLE` | — | — |
+| `scientific_name` | `text` | — | — |
+| `snow_mm` | `DOUBLE` | — | — |
+| `species_code` | `text` | missing (must_be=0) | — |
+| `temp_range_c` | `DOUBLE` | — | — |
+| `tmax_c` | `DOUBLE` | — | — |
+| `tmin_c` | `DOUBLE` | — | — |
+| `total_birds_counted` | `bigint` | — | — |
+| `usgs_last_loaded_at` | `TIMESTAMP` | — | — |
+| `wind_ms` | `DOUBLE` | — | — |
+
+## Table-level checks
+
+- **duplicate** — columns=['species_code', 'h3_cell', 'obs_date'], must_be=0
+- **row_count** — must_be_greater_than=0
+
+## Lineage
+
+**Upstream**
+
+- [`ebird.int_observations_by_h3_day`](../ebird/int_observations_by_h3_day.md)
+- [`noaa.int_weather_by_h3_day`](../noaa/int_weather_by_h3_day.md)
+- [`usgs.int_streamflow_by_h3_day`](../usgs/int_streamflow_by_h3_day.md)
+
+## Example query
+
+```sql
+SELECT * FROM analytics.fct_species_environment_daily LIMIT 100;
+```

--- a/docs/dictionary/analytics/fct_species_weather_preferences.md
+++ b/docs/dictionary/analytics/fct_species_weather_preferences.md
@@ -1,0 +1,52 @@
+# analytics.fct_species_weather_preferences
+
+Per-species weather preference aggregates — what conditions correlate with each species appearing
+
+## Overview
+
+| Field | Value |
+| --- | --- |
+| Schema | `analytics` |
+| Name | `fct_species_weather_preferences` |
+| Kind | `FULL` |
+| Soda contract | [`soda/contracts/analytics/fct_species_weather_preferences.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/analytics/fct_species_weather_preferences.yaml) |
+
+## Columns
+
+| Column | Type | Checks | Notes |
+| --- | --- | --- | --- |
+| `avg_high_temp_c` | `DOUBLE` | — | — |
+| `avg_low_temp_c` | `DOUBLE` | — | — |
+| `avg_precip_mm` | `DOUBLE` | — | — |
+| `avg_wind_ms` | `DOUBLE` | — | — |
+| `coldest_day_high_c` | `DOUBLE` | — | — |
+| `common_name` | `UNKNOWN` | missing (must_be=0) | — |
+| `dominant_season` | `TEXT` | — | — |
+| `family_common_name` | `UNKNOWN` | — | — |
+| `hottest_day_high_c` | `DOUBLE` | — | — |
+| `last_updated_at` | `TIMESTAMP` | — | — |
+| `p25_high_temp_c` | `DOUBLE` | — | — |
+| `p75_high_temp_c` | `DOUBLE` | — | — |
+| `pct_rainy_days` | `DOUBLE` | — | — |
+| `scientific_name` | `UNKNOWN` | — | — |
+| `species_code` | `UNKNOWN` | missing (must_be=0), duplicate (must_be=0) | — |
+| `taxonomic_category` | `UNKNOWN` | — | — |
+| `total_observation_days` | `BIGINT` | missing (must_be=0) | — |
+| `total_observations` | `BIGINT` | missing (must_be=0) | — |
+
+## Table-level checks
+
+- **row_count** — must_be_greater_than=0
+- **freshness** — column=last_updated_at, threshold={'unit': 'hour', 'must_be_less_than': 25}
+
+## Lineage
+
+**Upstream**
+
+- [`analytics.fct_bird_weather_daily`](fct_bird_weather_daily.md)
+
+## Example query
+
+```sql
+SELECT * FROM analytics.fct_species_weather_preferences LIMIT 100;
+```

--- a/docs/dictionary/analytics/fct_species_weather_preferences.md
+++ b/docs/dictionary/analytics/fct_species_weather_preferences.md
@@ -9,7 +9,7 @@ Per-species weather preference aggregates — what conditions correlate with eac
 | Schema | `analytics` |
 | Name | `fct_species_weather_preferences` |
 | Kind | `FULL` |
-| Soda contract | [`soda/contracts/analytics/fct_species_weather_preferences.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/analytics/fct_species_weather_preferences.yaml) |
+| Soda contract | [`soda/contracts/analytics/fct_species_weather_preferences.yaml`](https://github.com/Doctacon/databox/blob/main/soda/contracts/analytics/fct_species_weather_preferences.yaml) |
 
 ## Columns
 

--- a/docs/dictionary/analytics/platform_health.md
+++ b/docs/dictionary/analytics/platform_health.md
@@ -9,7 +9,7 @@ Per-source load observability — most recent dlt load id, completion time, stat
 | Schema | `analytics` |
 | Name | `platform_health` |
 | Kind | `VIEW` |
-| Soda contract | [`soda/contracts/analytics/platform_health.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/analytics/platform_health.yaml) |
+| Soda contract | [`soda/contracts/analytics/platform_health.yaml`](https://github.com/Doctacon/databox/blob/main/soda/contracts/analytics/platform_health.yaml) |
 
 ## Columns
 

--- a/docs/dictionary/analytics/platform_health.md
+++ b/docs/dictionary/analytics/platform_health.md
@@ -1,0 +1,51 @@
+# analytics.platform_health
+
+Per-source load observability — most recent dlt load id, completion time, status, and row volume. One row per source.
+
+## Overview
+
+| Field | Value |
+| --- | --- |
+| Schema | `analytics` |
+| Name | `platform_health` |
+| Kind | `VIEW` |
+| Soda contract | [`soda/contracts/analytics/platform_health.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/analytics/platform_health.yaml) |
+
+## Columns
+
+| Column | Type | Checks | Notes |
+| --- | --- | --- | --- |
+| `age` | `UNKNOWN` | — | — |
+| `completed_at` | `UNKNOWN` | missing (must_be=0) | — |
+| `load_id` | `UNKNOWN` | missing (must_be=0) | — |
+| `rows_loaded` | `UNKNOWN` | — | — |
+| `schema_name` | `UNKNOWN` | — | — |
+| `source` | `UNKNOWN` | missing (must_be=0), invalid (valid_values=['ebird', 'noaa', 'usgs'], must_be=0) | — |
+| `status` | `UNKNOWN` | missing (must_be=0) | — |
+| `status_label` | `TEXT` | — | — |
+
+## Table-level checks
+
+- **row_count** — must_be=3
+
+## Lineage
+
+**Upstream**
+
+- `main._dlt_loads` (external)
+- `main.hotspots` (external)
+- `main.notable_observations` (external)
+- `main.recent_observations` (external)
+- `main.species_list` (external)
+- `main._dlt_loads` (external)
+- `main.daily_weather` (external)
+- `main.stations` (external)
+- `main._dlt_loads` (external)
+- `main.daily_values` (external)
+- `main.sites` (external)
+
+## Example query
+
+```sql
+SELECT * FROM analytics.platform_health LIMIT 100;
+```

--- a/docs/dictionary/ebird/dim_species.md
+++ b/docs/dictionary/ebird/dim_species.md
@@ -1,0 +1,42 @@
+# ebird.dim_species
+
+Species dimension from eBird taxonomy — one row per species_code
+
+## Overview
+
+| Field | Value |
+| --- | --- |
+| Schema | `ebird` |
+| Name | `dim_species` |
+| Kind | `FULL` |
+| Soda contract | [`soda/contracts/ebird/dim_species.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/ebird/dim_species.yaml) |
+
+## Columns
+
+| Column | Type | Checks | Notes |
+| --- | --- | --- | --- |
+| `common_name` | `UNKNOWN` | missing (must_be=0) | — |
+| `family_common_name` | `UNKNOWN` | — | — |
+| `family_scientific_name` | `UNKNOWN` | — | — |
+| `loaded_at` | `TIMESTAMP` | — | — |
+| `scientific_name` | `UNKNOWN` | — | — |
+| `species_code` | `UNKNOWN` | missing (must_be=0), duplicate (must_be=0) | — |
+| `taxonomic_category` | `UNKNOWN` | — | — |
+| `taxonomic_order` | `UNKNOWN` | — | — |
+
+## Table-level checks
+
+- **row_count** — must_be_greater_than=0
+- **freshness** — column=loaded_at, threshold={'unit': 'hour', 'must_be_less_than': 25}
+
+## Lineage
+
+**Upstream**
+
+- [`ebird_staging.stg_ebird_taxonomy`](../ebird_staging/stg_ebird_taxonomy.md)
+
+## Example query
+
+```sql
+SELECT * FROM ebird.dim_species LIMIT 100;
+```

--- a/docs/dictionary/ebird/dim_species.md
+++ b/docs/dictionary/ebird/dim_species.md
@@ -9,7 +9,7 @@ Species dimension from eBird taxonomy — one row per species_code
 | Schema | `ebird` |
 | Name | `dim_species` |
 | Kind | `FULL` |
-| Soda contract | [`soda/contracts/ebird/dim_species.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/ebird/dim_species.yaml) |
+| Soda contract | [`soda/contracts/ebird/dim_species.yaml`](https://github.com/Doctacon/databox/blob/main/soda/contracts/ebird/dim_species.yaml) |
 
 ## Columns
 

--- a/docs/dictionary/ebird/fct_daily_bird_observations.md
+++ b/docs/dictionary/ebird/fct_daily_bird_observations.md
@@ -1,0 +1,70 @@
+# ebird.fct_daily_bird_observations
+
+Daily bird observation facts aggregated by region, date, and species
+
+## Overview
+
+| Field | Value |
+| --- | --- |
+| Schema | `ebird` |
+| Name | `fct_daily_bird_observations` |
+| Kind | `FULL` |
+| Soda contract | [`soda/contracts/ebird/fct_daily_bird_observations.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/ebird/fct_daily_bird_observations.yaml) |
+
+## Columns
+
+| Column | Type | Checks | Notes |
+| --- | --- | --- | --- |
+| `afternoon_observations` | `BIGINT` | — | — |
+| `avg_flock_size` | `DOUBLE` | — | — |
+| `avg_observations_per_location` | `DOUBLE` | — | — |
+| `common_name` | `UNKNOWN` | missing (must_be=0) | — |
+| `counted_observations` | `BIGINT` | — | — |
+| `evening_observations` | `BIGINT` | — | — |
+| `family_common_name` | `UNKNOWN` | — | — |
+| `first_loaded_at` | `UNKNOWN` | — | — |
+| `flock_observations` | `BIGINT` | — | — |
+| `last_loaded_at` | `UNKNOWN` | — | — |
+| `last_updated_at` | `TIMESTAMP` | — | — |
+| `location_count` | `BIGINT` | — | — |
+| `max_flock_size` | `UNKNOWN` | — | — |
+| `morning_observations` | `BIGINT` | — | — |
+| `night_observations` | `BIGINT` | — | — |
+| `notable_observations` | `BIGINT` | — | — |
+| `observation_count` | `BIGINT` | missing (must_be=0) | — |
+| `observation_date` | `UNKNOWN` | missing (must_be=0) | — |
+| `pct_counted_observations` | `DOUBLE` | — | — |
+| `pct_valid_observations` | `DOUBLE` | — | — |
+| `popularity_score` | `DOUBLE` | — | — |
+| `presence_only_observations` | `BIGINT` | — | — |
+| `region_code` | `UNKNOWN` | missing (must_be=0) | — |
+| `reviewed_observations` | `BIGINT` | — | — |
+| `scientific_name` | `UNKNOWN` | — | — |
+| `season` | `TEXT` | — | — |
+| `species_code` | `UNKNOWN` | missing (must_be=0) | — |
+| `submission_count` | `BIGINT` | — | — |
+| `taxonomic_category` | `UNKNOWN` | — | — |
+| `total_birds_counted` | `UNKNOWN` | — | — |
+| `unique_locations_approx` | `BIGINT` | — | — |
+| `valid_observations` | `BIGINT` | — | — |
+
+## Table-level checks
+
+- **row_count** — must_be_greater_than=0
+- **freshness** — column=last_updated_at, threshold={'unit': 'hour', 'must_be_less_than': 25}
+
+## Lineage
+
+**Upstream**
+
+- [`ebird.int_ebird_enriched_observations`](int_ebird_enriched_observations.md)
+
+**Downstream**
+
+- [`analytics.fct_bird_weather_daily`](../analytics/fct_bird_weather_daily.md)
+
+## Example query
+
+```sql
+SELECT * FROM ebird.fct_daily_bird_observations LIMIT 100;
+```

--- a/docs/dictionary/ebird/fct_daily_bird_observations.md
+++ b/docs/dictionary/ebird/fct_daily_bird_observations.md
@@ -9,7 +9,7 @@ Daily bird observation facts aggregated by region, date, and species
 | Schema | `ebird` |
 | Name | `fct_daily_bird_observations` |
 | Kind | `FULL` |
-| Soda contract | [`soda/contracts/ebird/fct_daily_bird_observations.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/ebird/fct_daily_bird_observations.yaml) |
+| Soda contract | [`soda/contracts/ebird/fct_daily_bird_observations.yaml`](https://github.com/Doctacon/databox/blob/main/soda/contracts/ebird/fct_daily_bird_observations.yaml) |
 
 ## Columns
 

--- a/docs/dictionary/ebird/fct_hotspot_species_diversity.md
+++ b/docs/dictionary/ebird/fct_hotspot_species_diversity.md
@@ -9,7 +9,7 @@ Per-hotspot biodiversity metrics including Shannon diversity index and species r
 | Schema | `ebird` |
 | Name | `fct_hotspot_species_diversity` |
 | Kind | `FULL` |
-| Soda contract | [`soda/contracts/ebird/fct_hotspot_species_diversity.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/ebird/fct_hotspot_species_diversity.yaml) |
+| Soda contract | [`soda/contracts/ebird/fct_hotspot_species_diversity.yaml`](https://github.com/Doctacon/databox/blob/main/soda/contracts/ebird/fct_hotspot_species_diversity.yaml) |
 
 ## Columns
 

--- a/docs/dictionary/ebird/fct_hotspot_species_diversity.md
+++ b/docs/dictionary/ebird/fct_hotspot_species_diversity.md
@@ -1,0 +1,51 @@
+# ebird.fct_hotspot_species_diversity
+
+Per-hotspot biodiversity metrics including Shannon diversity index and species richness
+
+## Overview
+
+| Field | Value |
+| --- | --- |
+| Schema | `ebird` |
+| Name | `fct_hotspot_species_diversity` |
+| Kind | `FULL` |
+| Soda contract | [`soda/contracts/ebird/fct_hotspot_species_diversity.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/ebird/fct_hotspot_species_diversity.yaml) |
+
+## Columns
+
+| Column | Type | Checks | Notes |
+| --- | --- | --- | --- |
+| `county_code` | `UNKNOWN` | — | — |
+| `first_observation_date` | `UNKNOWN` | — | — |
+| `last_loaded_at` | `UNKNOWN` | — | — |
+| `last_observation_date` | `UNKNOWN` | — | — |
+| `last_updated_at` | `TIMESTAMP` | — | — |
+| `latitude` | `UNKNOWN` | — | — |
+| `location_id` | `UNKNOWN` | missing (must_be=0), duplicate (must_be=0) | — |
+| `location_name` | `UNKNOWN` | — | — |
+| `longitude` | `UNKNOWN` | — | — |
+| `most_common_species_code` | `UNKNOWN` | — | — |
+| `most_common_species_name` | `UNKNOWN` | — | — |
+| `pct_notable_observations` | `DOUBLE` | — | — |
+| `peak_season` | `TEXT` | — | — |
+| `shannon_diversity_index` | `DOUBLE` | — | — |
+| `state_code` | `UNKNOWN` | — | — |
+| `total_observations` | `BIGINT` | missing (must_be=0) | — |
+| `total_species_count` | `BIGINT` | missing (must_be=0) | — |
+
+## Table-level checks
+
+- **row_count** — must_be_greater_than=0
+- **freshness** — column=last_updated_at, threshold={'unit': 'hour', 'must_be_less_than': 25}
+
+## Lineage
+
+**Upstream**
+
+- [`ebird.int_ebird_enriched_observations`](int_ebird_enriched_observations.md)
+
+## Example query
+
+```sql
+SELECT * FROM ebird.fct_hotspot_species_diversity LIMIT 100;
+```

--- a/docs/dictionary/ebird/int_ebird_enriched_observations.md
+++ b/docs/dictionary/ebird/int_ebird_enriched_observations.md
@@ -9,7 +9,7 @@ Intermediate model with enriched bird observations including taxonomy and locati
 | Schema | `ebird` |
 | Name | `int_ebird_enriched_observations` |
 | Kind | `FULL` |
-| Soda contract | [`soda/contracts/ebird/int_ebird_enriched_observations.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/ebird/int_ebird_enriched_observations.yaml) |
+| Soda contract | [`soda/contracts/ebird/int_ebird_enriched_observations.yaml`](https://github.com/Doctacon/databox/blob/main/soda/contracts/ebird/int_ebird_enriched_observations.yaml) |
 
 ## Columns
 

--- a/docs/dictionary/ebird/int_ebird_enriched_observations.md
+++ b/docs/dictionary/ebird/int_ebird_enriched_observations.md
@@ -1,0 +1,76 @@
+# ebird.int_ebird_enriched_observations
+
+Intermediate model with enriched bird observations including taxonomy and location details
+
+## Overview
+
+| Field | Value |
+| --- | --- |
+| Schema | `ebird` |
+| Name | `int_ebird_enriched_observations` |
+| Kind | `FULL` |
+| Soda contract | [`soda/contracts/ebird/int_ebird_enriched_observations.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/ebird/int_ebird_enriched_observations.yaml) |
+
+## Columns
+
+| Column | Type | Checks | Notes |
+| --- | --- | --- | --- |
+| `common_name` | `UNKNOWN` | missing (must_be=0) | — |
+| `count` | `UNKNOWN` | — | — |
+| `count_display` | `UNKNOWN` | — | — |
+| `country_code` | `UNKNOWN` | — | — |
+| `county_code` | `UNKNOWN` | — | — |
+| `distance_from_hotspot_miles` | `DOUBLE` | — | — |
+| `family_common_name` | `UNKNOWN` | — | — |
+| `family_scientific_name` | `UNKNOWN` | — | — |
+| `hotspot_latest_observation` | `TIMESTAMP` | — | — |
+| `hotspot_total_species` | `UNKNOWN` | — | — |
+| `is_flock` | `BOOLEAN` | — | — |
+| `is_location_private` | `UNKNOWN` | — | — |
+| `is_notable` | `UNKNOWN` | — | — |
+| `is_reviewed` | `UNKNOWN` | — | — |
+| `is_valid` | `UNKNOWN` | — | — |
+| `latitude` | `UNKNOWN` | — | — |
+| `loaded_at` | `UNKNOWN` | — | — |
+| `location_id` | `UNKNOWN` | missing (must_be=0) | — |
+| `location_name` | `UNKNOWN` | — | — |
+| `longitude` | `UNKNOWN` | — | — |
+| `observation_date` | `UNKNOWN` | missing (must_be=0) | — |
+| `observation_datetime` | `UNKNOWN` | missing (must_be=0) | — |
+| `observation_day` | `UNKNOWN` | — | — |
+| `observation_hour` | `UNKNOWN` | — | — |
+| `observation_month` | `UNKNOWN` | — | — |
+| `observation_year` | `UNKNOWN` | — | — |
+| `region_code` | `UNKNOWN` | — | — |
+| `scientific_name` | `UNKNOWN` | — | — |
+| `season` | `TEXT` | — | — |
+| `species_code` | `UNKNOWN` | missing (must_be=0) | — |
+| `state_code` | `UNKNOWN` | — | — |
+| `submission_id` | `UNKNOWN` | missing (must_be=0) | — |
+| `taxonomic_category` | `UNKNOWN` | — | — |
+| `taxonomic_order` | `UNKNOWN` | — | — |
+| `time_of_day` | `TEXT` | — | — |
+
+## Table-level checks
+
+- **row_count** — must_be_greater_than=0
+- **freshness** — column=loaded_at, threshold={'unit': 'hour', 'must_be_less_than': 25}
+
+## Lineage
+
+**Upstream**
+
+- [`ebird_staging.stg_ebird_hotspots`](../ebird_staging/stg_ebird_hotspots.md)
+- [`ebird_staging.stg_ebird_observations`](../ebird_staging/stg_ebird_observations.md)
+- [`ebird_staging.stg_ebird_taxonomy`](../ebird_staging/stg_ebird_taxonomy.md)
+
+**Downstream**
+
+- [`ebird.fct_daily_bird_observations`](fct_daily_bird_observations.md)
+- [`ebird.fct_hotspot_species_diversity`](fct_hotspot_species_diversity.md)
+
+## Example query
+
+```sql
+SELECT * FROM ebird.int_ebird_enriched_observations LIMIT 100;
+```

--- a/docs/dictionary/ebird/int_observations_by_h3_day.md
+++ b/docs/dictionary/ebird/int_observations_by_h3_day.md
@@ -1,0 +1,45 @@
+# ebird.int_observations_by_h3_day
+
+eBird observations rolled up to H3 cell x species x observation_date. H3 resolution 6 (~36 km^2 hex). Feeds analytics.fct_species_environment_daily.
+
+## Overview
+
+| Field | Value |
+| --- | --- |
+| Schema | `ebird` |
+| Name | `int_observations_by_h3_day` |
+| Kind | `FULL` |
+| Soda contract | _none_ |
+
+## Columns
+
+| Column | Type | Checks | Notes |
+| --- | --- | --- | --- |
+| `common_name` | `UNKNOWN` | — | — |
+| `h3_cell` | `UNKNOWN` | — | — |
+| `last_loaded_at` | `UNKNOWN` | — | — |
+| `n_checklists` | `BIGINT` | — | — |
+| `n_notable_observations` | `BIGINT` | — | — |
+| `n_observations` | `BIGINT` | — | — |
+| `observation_date` | `UNKNOWN` | — | — |
+| `scientific_name` | `UNKNOWN` | — | — |
+| `species_code` | `UNKNOWN` | — | — |
+| `total_birds_counted` | `UNKNOWN` | — | — |
+
+## Lineage
+
+**Upstream**
+
+- [`ebird_staging.stg_ebird_observations`](../ebird_staging/stg_ebird_observations.md)
+
+**Downstream**
+
+- [`analytics.fct_species_environment_daily`](../analytics/fct_species_environment_daily.md)
+- [`noaa.int_weather_by_h3_day`](../noaa/int_weather_by_h3_day.md)
+- [`usgs.int_streamflow_by_h3_day`](../usgs/int_streamflow_by_h3_day.md)
+
+## Example query
+
+```sql
+SELECT * FROM ebird.int_observations_by_h3_day LIMIT 100;
+```

--- a/docs/dictionary/ebird_staging/stg_ebird_hotspots.md
+++ b/docs/dictionary/ebird_staging/stg_ebird_hotspots.md
@@ -1,0 +1,49 @@
+# ebird_staging.stg_ebird_hotspots
+
+Staging model for eBird birding hotspots
+
+## Overview
+
+| Field | Value |
+| --- | --- |
+| Schema | `ebird_staging` |
+| Name | `stg_ebird_hotspots` |
+| Kind | `FULL` |
+| Soda contract | [`soda/contracts/ebird_staging/stg_ebird_hotspots.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/ebird_staging/stg_ebird_hotspots.yaml) |
+
+## Columns
+
+| Column | Type | Checks | Notes |
+| --- | --- | --- | --- |
+| `country_code` | `UNKNOWN` | — | — |
+| `county_code` | `UNKNOWN` | — | — |
+| `latest_observation_datetime` | `TIMESTAMP` | — | — |
+| `latitude` | `DOUBLE` | — | — |
+| `loaded_at` | `TIMESTAMP` | — | — |
+| `location_id` | `UNKNOWN` | missing (must_be=0), duplicate (must_be=0) | — |
+| `location_name` | `UNKNOWN` | missing (must_be=0) | — |
+| `longitude` | `DOUBLE` | — | — |
+| `region_code` | `UNKNOWN` | — | — |
+| `state_code` | `UNKNOWN` | — | — |
+| `total_species_count` | `UNKNOWN` | — | — |
+
+## Table-level checks
+
+- **row_count** — must_be_greater_than=0
+- **freshness** — column=loaded_at, threshold={'unit': 'hour', 'must_be_less_than': 25}
+
+## Lineage
+
+**Upstream**
+
+- `main.hotspots` (external)
+
+**Downstream**
+
+- [`ebird.int_ebird_enriched_observations`](../ebird/int_ebird_enriched_observations.md)
+
+## Example query
+
+```sql
+SELECT * FROM ebird_staging.stg_ebird_hotspots LIMIT 100;
+```

--- a/docs/dictionary/ebird_staging/stg_ebird_hotspots.md
+++ b/docs/dictionary/ebird_staging/stg_ebird_hotspots.md
@@ -9,7 +9,7 @@ Staging model for eBird birding hotspots
 | Schema | `ebird_staging` |
 | Name | `stg_ebird_hotspots` |
 | Kind | `FULL` |
-| Soda contract | [`soda/contracts/ebird_staging/stg_ebird_hotspots.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/ebird_staging/stg_ebird_hotspots.yaml) |
+| Soda contract | [`soda/contracts/ebird_staging/stg_ebird_hotspots.yaml`](https://github.com/Doctacon/databox/blob/main/soda/contracts/ebird_staging/stg_ebird_hotspots.yaml) |
 
 ## Columns
 

--- a/docs/dictionary/ebird_staging/stg_ebird_observations.md
+++ b/docs/dictionary/ebird_staging/stg_ebird_observations.md
@@ -1,0 +1,62 @@
+# ebird_staging.stg_ebird_observations
+
+Staging model for eBird bird observations
+
+## Overview
+
+| Field | Value |
+| --- | --- |
+| Schema | `ebird_staging` |
+| Name | `stg_ebird_observations` |
+| Kind | `FULL` |
+| Soda contract | [`soda/contracts/ebird_staging/stg_ebird_observations.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/ebird_staging/stg_ebird_observations.yaml) |
+
+## Columns
+
+| Column | Type | Checks | Notes |
+| --- | --- | --- | --- |
+| `common_name` | `UNKNOWN` | missing (must_be=0) | — |
+| `count` | `UNKNOWN` | — | — |
+| `count_display` | `UNKNOWN` | — | — |
+| `is_location_private` | `UNKNOWN` | — | — |
+| `is_notable` | `UNKNOWN` | — | — |
+| `is_reviewed` | `UNKNOWN` | — | — |
+| `is_valid` | `UNKNOWN` | — | — |
+| `latitude` | `UNKNOWN` | — | — |
+| `loaded_at` | `UNKNOWN` | — | — |
+| `location_id` | `UNKNOWN` | missing (must_be=0) | — |
+| `location_name` | `UNKNOWN` | — | — |
+| `longitude` | `UNKNOWN` | — | — |
+| `observation_date` | `UNKNOWN` | missing (must_be=0) | — |
+| `observation_datetime` | `UNKNOWN` | missing (must_be=0) | — |
+| `observation_day` | `UNKNOWN` | — | — |
+| `observation_hour` | `UNKNOWN` | — | — |
+| `observation_month` | `UNKNOWN` | — | — |
+| `observation_year` | `UNKNOWN` | — | — |
+| `region_code` | `UNKNOWN` | missing (must_be=0) | — |
+| `scientific_name` | `UNKNOWN` | — | — |
+| `species_code` | `UNKNOWN` | missing (must_be=0) | — |
+| `submission_id` | `UNKNOWN` | missing (must_be=0), duplicate (must_be=0) | — |
+
+## Table-level checks
+
+- **row_count** — must_be_greater_than=0
+- **freshness** — column=loaded_at, threshold={'unit': 'hour', 'must_be_less_than': 25}
+
+## Lineage
+
+**Upstream**
+
+- `main.notable_observations` (external)
+- `main.recent_observations` (external)
+
+**Downstream**
+
+- [`ebird.int_ebird_enriched_observations`](../ebird/int_ebird_enriched_observations.md)
+- [`ebird.int_observations_by_h3_day`](../ebird/int_observations_by_h3_day.md)
+
+## Example query
+
+```sql
+SELECT * FROM ebird_staging.stg_ebird_observations LIMIT 100;
+```

--- a/docs/dictionary/ebird_staging/stg_ebird_observations.md
+++ b/docs/dictionary/ebird_staging/stg_ebird_observations.md
@@ -9,7 +9,7 @@ Staging model for eBird bird observations
 | Schema | `ebird_staging` |
 | Name | `stg_ebird_observations` |
 | Kind | `FULL` |
-| Soda contract | [`soda/contracts/ebird_staging/stg_ebird_observations.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/ebird_staging/stg_ebird_observations.yaml) |
+| Soda contract | [`soda/contracts/ebird_staging/stg_ebird_observations.yaml`](https://github.com/Doctacon/databox/blob/main/soda/contracts/ebird_staging/stg_ebird_observations.yaml) |
 
 ## Columns
 

--- a/docs/dictionary/ebird_staging/stg_ebird_taxonomy.md
+++ b/docs/dictionary/ebird_staging/stg_ebird_taxonomy.md
@@ -1,0 +1,47 @@
+# ebird_staging.stg_ebird_taxonomy
+
+Staging model for eBird taxonomy reference data
+
+## Overview
+
+| Field | Value |
+| --- | --- |
+| Schema | `ebird_staging` |
+| Name | `stg_ebird_taxonomy` |
+| Kind | `FULL` |
+| Soda contract | [`soda/contracts/ebird_staging/stg_ebird_taxonomy.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/ebird_staging/stg_ebird_taxonomy.yaml) |
+
+## Columns
+
+| Column | Type | Checks | Notes |
+| --- | --- | --- | --- |
+| `common_name` | `UNKNOWN` | missing (must_be=0) | — |
+| `family_common_name` | `UNKNOWN` | — | — |
+| `family_scientific_name` | `UNKNOWN` | — | — |
+| `loaded_at` | `TIMESTAMP` | — | — |
+| `scientific_name` | `UNKNOWN` | missing (must_be=0) | — |
+| `species_code` | `UNKNOWN` | missing (must_be=0), duplicate (must_be=0) | — |
+| `taxonomic_category` | `UNKNOWN` | — | — |
+| `taxonomic_order` | `UNKNOWN` | — | — |
+
+## Table-level checks
+
+- **row_count** — must_be_greater_than=0
+- **freshness** — column=loaded_at, threshold={'unit': 'hour', 'must_be_less_than': 25}
+
+## Lineage
+
+**Upstream**
+
+- `main.taxonomy` (external)
+
+**Downstream**
+
+- [`ebird.dim_species`](../ebird/dim_species.md)
+- [`ebird.int_ebird_enriched_observations`](../ebird/int_ebird_enriched_observations.md)
+
+## Example query
+
+```sql
+SELECT * FROM ebird_staging.stg_ebird_taxonomy LIMIT 100;
+```

--- a/docs/dictionary/ebird_staging/stg_ebird_taxonomy.md
+++ b/docs/dictionary/ebird_staging/stg_ebird_taxonomy.md
@@ -9,7 +9,7 @@ Staging model for eBird taxonomy reference data
 | Schema | `ebird_staging` |
 | Name | `stg_ebird_taxonomy` |
 | Kind | `FULL` |
-| Soda contract | [`soda/contracts/ebird_staging/stg_ebird_taxonomy.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/ebird_staging/stg_ebird_taxonomy.yaml) |
+| Soda contract | [`soda/contracts/ebird_staging/stg_ebird_taxonomy.yaml`](https://github.com/Doctacon/databox/blob/main/soda/contracts/ebird_staging/stg_ebird_taxonomy.yaml) |
 
 ## Columns
 

--- a/docs/dictionary/index.md
+++ b/docs/dictionary/index.md
@@ -1,0 +1,76 @@
+# Data dictionary
+
+Auto-generated from SQLMesh model metadata and Soda contracts. Regenerate with `uv run python scripts/generate_docs.py`.
+
+- **Models:** 20
+- **Soda contracts:** 24
+- **Lineage:** [browse the dependency graph](lineage.md)
+
+## `analytics`
+
+Cross-domain marts that join bird, weather, and streamflow signals.
+
+| Model | Contract | Description |
+| --- | --- | --- |
+| [`analytics.fct_bird_weather_daily`](analytics/fct_bird_weather_daily.md) | yes | eBird daily observations joined with NOAA weather conditions — one row per region x date x species |
+| [`analytics.fct_species_environment_daily`](analytics/fct_species_environment_daily.md) | yes | Flagship cross-domain mart: bird observations joined to daily weather and streamflow at species x H3 cell (resolution 6, ~36 km^2) x day grain |
+| [`analytics.fct_species_weather_preferences`](analytics/fct_species_weather_preferences.md) | yes | Per-species weather preference aggregates — what conditions correlate with each species appearing |
+| [`analytics.platform_health`](analytics/platform_health.md) | yes | Per-source load observability — most recent dlt load id, completion time, status, and row volume |
+
+## `ebird`
+
+eBird bird-observation domain — intermediate and mart models.
+
+| Model | Contract | Description |
+| --- | --- | --- |
+| [`ebird.dim_species`](ebird/dim_species.md) | yes | Species dimension from eBird taxonomy — one row per species_code |
+| [`ebird.fct_daily_bird_observations`](ebird/fct_daily_bird_observations.md) | yes | Daily bird observation facts aggregated by region, date, and species |
+| [`ebird.fct_hotspot_species_diversity`](ebird/fct_hotspot_species_diversity.md) | yes | Per-hotspot biodiversity metrics including Shannon diversity index and species richness |
+| [`ebird.int_ebird_enriched_observations`](ebird/int_ebird_enriched_observations.md) | yes | Intermediate model with enriched bird observations including taxonomy and location details |
+| [`ebird.int_observations_by_h3_day`](ebird/int_observations_by_h3_day.md) | — | eBird observations rolled up to H3 cell x species x observation_date |
+
+## `ebird_staging`
+
+eBird staging views — raw dlt loads with column renames only.
+
+| Model | Contract | Description |
+| --- | --- | --- |
+| [`ebird_staging.stg_ebird_hotspots`](ebird_staging/stg_ebird_hotspots.md) | yes | Staging model for eBird birding hotspots |
+| [`ebird_staging.stg_ebird_observations`](ebird_staging/stg_ebird_observations.md) | yes | Staging model for eBird bird observations |
+| [`ebird_staging.stg_ebird_taxonomy`](ebird_staging/stg_ebird_taxonomy.md) | yes | Staging model for eBird taxonomy reference data |
+
+## `noaa`
+
+NOAA weather domain — intermediate and mart models.
+
+| Model | Contract | Description |
+| --- | --- | --- |
+| [`noaa.fct_daily_weather`](noaa/fct_daily_weather.md) | yes | Daily weather facts pivoted from normalized observations to one row per station per date |
+| [`noaa.int_weather_by_h3_day`](noaa/int_weather_by_h3_day.md) | — | Daily NOAA weather assigned to each H3 cell in the bird-observation universe via nearest-station join |
+
+## `noaa_staging`
+
+NOAA staging views — raw dlt loads with column renames only.
+
+| Model | Contract | Description |
+| --- | --- | --- |
+| [`noaa_staging.stg_noaa_daily_weather`](noaa_staging/stg_noaa_daily_weather.md) | yes | Staging model for NOAA daily weather observations |
+| [`noaa_staging.stg_noaa_stations`](noaa_staging/stg_noaa_stations.md) | yes | Staging model for NOAA weather stations |
+
+## `usgs`
+
+USGS streamflow domain — intermediate and mart models.
+
+| Model | Contract | Description |
+| --- | --- | --- |
+| [`usgs.fct_daily_streamflow`](usgs/fct_daily_streamflow.md) | yes | Daily streamflow facts pivoted to one row per site per date with key hydrological metrics |
+| [`usgs.int_streamflow_by_h3_day`](usgs/int_streamflow_by_h3_day.md) | — | Daily USGS streamflow assigned to each H3 cell in the bird-observation universe via nearest-gauge join |
+
+## `usgs_staging`
+
+USGS staging views — raw dlt loads with column renames only.
+
+| Model | Contract | Description |
+| --- | --- | --- |
+| [`usgs_staging.stg_usgs_daily_values`](usgs_staging/stg_usgs_daily_values.md) | yes | Staging model for USGS daily streamflow and gage observations |
+| [`usgs_staging.stg_usgs_sites`](usgs_staging/stg_usgs_sites.md) | yes | Staging model for USGS monitoring site metadata |

--- a/docs/dictionary/lineage.md
+++ b/docs/dictionary/lineage.md
@@ -1,0 +1,70 @@
+# Lineage
+
+Full model dependency graph across all SQLMesh projects. Each node links to its data-dictionary page.
+
+```mermaid
+graph LR
+    n0["analytics.fct_bird_weather_daily"]
+    n1["analytics.fct_species_environment_daily"]
+    n2["analytics.fct_species_weather_preferences"]
+    n3["analytics.platform_health"]
+    n4["ebird.dim_species"]
+    n5["ebird.fct_daily_bird_observations"]
+    n6["ebird.fct_hotspot_species_diversity"]
+    n7["ebird.int_ebird_enriched_observations"]
+    n8["ebird.int_observations_by_h3_day"]
+    n9["ebird_staging.stg_ebird_hotspots"]
+    n10["ebird_staging.stg_ebird_observations"]
+    n11["ebird_staging.stg_ebird_taxonomy"]
+    n12["noaa.fct_daily_weather"]
+    n13["noaa.int_weather_by_h3_day"]
+    n14["noaa_staging.stg_noaa_daily_weather"]
+    n15["noaa_staging.stg_noaa_stations"]
+    n16["usgs.fct_daily_streamflow"]
+    n17["usgs.int_streamflow_by_h3_day"]
+    n18["usgs_staging.stg_usgs_daily_values"]
+    n19["usgs_staging.stg_usgs_sites"]
+    n5 --> n0
+    n12 --> n0
+    n8 --> n1
+    n13 --> n1
+    n17 --> n1
+    n0 --> n2
+    n11 --> n4
+    n7 --> n5
+    n7 --> n6
+    n9 --> n7
+    n10 --> n7
+    n11 --> n7
+    n10 --> n8
+    n14 --> n12
+    n8 --> n13
+    n12 --> n13
+    n15 --> n13
+    n18 --> n16
+    n19 --> n16
+    n8 --> n17
+    n16 --> n17
+    n19 --> n17
+
+    click n0 "analytics/fct_bird_weather_daily.md"
+    click n1 "analytics/fct_species_environment_daily.md"
+    click n2 "analytics/fct_species_weather_preferences.md"
+    click n3 "analytics/platform_health.md"
+    click n4 "ebird/dim_species.md"
+    click n5 "ebird/fct_daily_bird_observations.md"
+    click n6 "ebird/fct_hotspot_species_diversity.md"
+    click n7 "ebird/int_ebird_enriched_observations.md"
+    click n8 "ebird/int_observations_by_h3_day.md"
+    click n9 "ebird_staging/stg_ebird_hotspots.md"
+    click n10 "ebird_staging/stg_ebird_observations.md"
+    click n11 "ebird_staging/stg_ebird_taxonomy.md"
+    click n12 "noaa/fct_daily_weather.md"
+    click n13 "noaa/int_weather_by_h3_day.md"
+    click n14 "noaa_staging/stg_noaa_daily_weather.md"
+    click n15 "noaa_staging/stg_noaa_stations.md"
+    click n16 "usgs/fct_daily_streamflow.md"
+    click n17 "usgs/int_streamflow_by_h3_day.md"
+    click n18 "usgs_staging/stg_usgs_daily_values.md"
+    click n19 "usgs_staging/stg_usgs_sites.md"
+```

--- a/docs/dictionary/noaa/fct_daily_weather.md
+++ b/docs/dictionary/noaa/fct_daily_weather.md
@@ -1,0 +1,55 @@
+# noaa.fct_daily_weather
+
+Daily weather facts pivoted from normalized observations to one row per station per date
+
+## Overview
+
+| Field | Value |
+| --- | --- |
+| Schema | `noaa` |
+| Name | `fct_daily_weather` |
+| Kind | `FULL` |
+| Soda contract | [`soda/contracts/noaa/fct_daily_weather.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/noaa/fct_daily_weather.yaml) |
+
+## Columns
+
+| Column | Type | Checks | Notes |
+| --- | --- | --- | --- |
+| `awnd` | `DOUBLE` | — | — |
+| `days_with_tmax_7d` | `BIGINT` | — | — |
+| `first_loaded_at` | `TIMESTAMP` | — | — |
+| `last_loaded_at` | `TIMESTAMP` | — | — |
+| `last_updated_at` | `TIMESTAMP` | — | — |
+| `location_id` | `UNKNOWN` | — | — |
+| `missing_value_count` | `BIGINT` | — | — |
+| `observation_count` | `BIGINT` | — | — |
+| `observation_date` | `DATE` | missing (must_be=0) | — |
+| `pct_data_completeness` | `DOUBLE` | — | — |
+| `prcp` | `DOUBLE` | — | — |
+| `snow` | `DOUBLE` | — | — |
+| `station` | `UNKNOWN` | missing (must_be=0) | — |
+| `temp_range` | `DOUBLE` | — | — |
+| `tmax` | `DOUBLE` | — | — |
+| `tmin` | `DOUBLE` | — | — |
+
+## Table-level checks
+
+- **row_count** — must_be_greater_than=0
+- **freshness** — column=last_updated_at, threshold={'unit': 'hour', 'must_be_less_than': 25}
+
+## Lineage
+
+**Upstream**
+
+- [`noaa_staging.stg_noaa_daily_weather`](../noaa_staging/stg_noaa_daily_weather.md)
+
+**Downstream**
+
+- [`analytics.fct_bird_weather_daily`](../analytics/fct_bird_weather_daily.md)
+- [`noaa.int_weather_by_h3_day`](int_weather_by_h3_day.md)
+
+## Example query
+
+```sql
+SELECT * FROM noaa.fct_daily_weather LIMIT 100;
+```

--- a/docs/dictionary/noaa/fct_daily_weather.md
+++ b/docs/dictionary/noaa/fct_daily_weather.md
@@ -9,7 +9,7 @@ Daily weather facts pivoted from normalized observations to one row per station 
 | Schema | `noaa` |
 | Name | `fct_daily_weather` |
 | Kind | `FULL` |
-| Soda contract | [`soda/contracts/noaa/fct_daily_weather.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/noaa/fct_daily_weather.yaml) |
+| Soda contract | [`soda/contracts/noaa/fct_daily_weather.yaml`](https://github.com/Doctacon/databox/blob/main/soda/contracts/noaa/fct_daily_weather.yaml) |
 
 ## Columns
 

--- a/docs/dictionary/noaa/int_weather_by_h3_day.md
+++ b/docs/dictionary/noaa/int_weather_by_h3_day.md
@@ -1,0 +1,45 @@
+# noaa.int_weather_by_h3_day
+
+Daily NOAA weather assigned to each H3 cell in the bird-observation universe via nearest-station join. Station-to-cell mapping is computed once; daily values join in after. H3 resolution 6 matches ebird.int_observations_by_h3_day.
+
+## Overview
+
+| Field | Value |
+| --- | --- |
+| Schema | `noaa` |
+| Name | `int_weather_by_h3_day` |
+| Kind | `FULL` |
+| Soda contract | _none_ |
+
+## Columns
+
+| Column | Type | Checks | Notes |
+| --- | --- | --- | --- |
+| `h3_cell` | `UNKNOWN` | — | — |
+| `last_loaded_at` | `TIMESTAMP` | — | — |
+| `nearest_station_distance_miles` | `DOUBLE` | — | — |
+| `nearest_station_id` | `UNKNOWN` | — | — |
+| `observation_date` | `DATE` | — | — |
+| `prcp_mm` | `DOUBLE` | — | — |
+| `snow_mm` | `DOUBLE` | — | — |
+| `tmax_c` | `DOUBLE` | — | — |
+| `tmin_c` | `DOUBLE` | — | — |
+| `wind_ms` | `DOUBLE` | — | — |
+
+## Lineage
+
+**Upstream**
+
+- [`ebird.int_observations_by_h3_day`](../ebird/int_observations_by_h3_day.md)
+- [`noaa.fct_daily_weather`](fct_daily_weather.md)
+- [`noaa_staging.stg_noaa_stations`](../noaa_staging/stg_noaa_stations.md)
+
+**Downstream**
+
+- [`analytics.fct_species_environment_daily`](../analytics/fct_species_environment_daily.md)
+
+## Example query
+
+```sql
+SELECT * FROM noaa.int_weather_by_h3_day LIMIT 100;
+```

--- a/docs/dictionary/noaa_staging/stg_noaa_daily_weather.md
+++ b/docs/dictionary/noaa_staging/stg_noaa_daily_weather.md
@@ -9,7 +9,7 @@ Staging model for NOAA daily weather observations
 | Schema | `noaa_staging` |
 | Name | `stg_noaa_daily_weather` |
 | Kind | `FULL` |
-| Soda contract | [`soda/contracts/noaa_staging/stg_noaa_daily_weather.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/noaa_staging/stg_noaa_daily_weather.yaml) |
+| Soda contract | [`soda/contracts/noaa_staging/stg_noaa_daily_weather.yaml`](https://github.com/Doctacon/databox/blob/main/soda/contracts/noaa_staging/stg_noaa_daily_weather.yaml) |
 
 ## Columns
 

--- a/docs/dictionary/noaa_staging/stg_noaa_daily_weather.md
+++ b/docs/dictionary/noaa_staging/stg_noaa_daily_weather.md
@@ -1,0 +1,46 @@
+# noaa_staging.stg_noaa_daily_weather
+
+Staging model for NOAA daily weather observations
+
+## Overview
+
+| Field | Value |
+| --- | --- |
+| Schema | `noaa_staging` |
+| Name | `stg_noaa_daily_weather` |
+| Kind | `FULL` |
+| Soda contract | [`soda/contracts/noaa_staging/stg_noaa_daily_weather.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/noaa_staging/stg_noaa_daily_weather.yaml) |
+
+## Columns
+
+| Column | Type | Checks | Notes |
+| --- | --- | --- | --- |
+| `attributes` | `UNKNOWN` | — | — |
+| `datatype` | `UNKNOWN` | missing (must_be=0) | — |
+| `loaded_at` | `TIMESTAMP` | — | — |
+| `location_id` | `UNKNOWN` | — | — |
+| `observation_date` | `DATE` | missing (must_be=0) | — |
+| `source` | `UNKNOWN` | — | — |
+| `station` | `UNKNOWN` | missing (must_be=0) | — |
+| `value` | `DOUBLE` | — | — |
+
+## Table-level checks
+
+- **row_count** — must_be_greater_than=0
+- **freshness** — column=loaded_at, threshold={'unit': 'hour', 'must_be_less_than': 25}
+
+## Lineage
+
+**Upstream**
+
+- `main.daily_weather` (external)
+
+**Downstream**
+
+- [`noaa.fct_daily_weather`](../noaa/fct_daily_weather.md)
+
+## Example query
+
+```sql
+SELECT * FROM noaa_staging.stg_noaa_daily_weather LIMIT 100;
+```

--- a/docs/dictionary/noaa_staging/stg_noaa_stations.md
+++ b/docs/dictionary/noaa_staging/stg_noaa_stations.md
@@ -1,0 +1,49 @@
+# noaa_staging.stg_noaa_stations
+
+Staging model for NOAA weather stations
+
+## Overview
+
+| Field | Value |
+| --- | --- |
+| Schema | `noaa_staging` |
+| Name | `stg_noaa_stations` |
+| Kind | `FULL` |
+| Soda contract | [`soda/contracts/noaa_staging/stg_noaa_stations.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/noaa_staging/stg_noaa_stations.yaml) |
+
+## Columns
+
+| Column | Type | Checks | Notes |
+| --- | --- | --- | --- |
+| `data_coverage` | `DOUBLE` | — | — |
+| `elevation` | `DOUBLE` | — | — |
+| `elevation_unit` | `UNKNOWN` | — | — |
+| `latitude` | `DOUBLE` | — | — |
+| `loaded_at` | `TIMESTAMP` | — | — |
+| `location_id` | `UNKNOWN` | — | — |
+| `longitude` | `DOUBLE` | — | — |
+| `max_date` | `DATE` | — | — |
+| `min_date` | `DATE` | — | — |
+| `station_id` | `UNKNOWN` | missing (must_be=0), duplicate (must_be=0) | — |
+| `station_name` | `UNKNOWN` | missing (must_be=0) | — |
+
+## Table-level checks
+
+- **row_count** — must_be_greater_than=0
+- **freshness** — column=loaded_at, threshold={'unit': 'hour', 'must_be_less_than': 25}
+
+## Lineage
+
+**Upstream**
+
+- `main.stations` (external)
+
+**Downstream**
+
+- [`noaa.int_weather_by_h3_day`](../noaa/int_weather_by_h3_day.md)
+
+## Example query
+
+```sql
+SELECT * FROM noaa_staging.stg_noaa_stations LIMIT 100;
+```

--- a/docs/dictionary/noaa_staging/stg_noaa_stations.md
+++ b/docs/dictionary/noaa_staging/stg_noaa_stations.md
@@ -9,7 +9,7 @@ Staging model for NOAA weather stations
 | Schema | `noaa_staging` |
 | Name | `stg_noaa_stations` |
 | Kind | `FULL` |
-| Soda contract | [`soda/contracts/noaa_staging/stg_noaa_stations.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/noaa_staging/stg_noaa_stations.yaml) |
+| Soda contract | [`soda/contracts/noaa_staging/stg_noaa_stations.yaml`](https://github.com/Doctacon/databox/blob/main/soda/contracts/noaa_staging/stg_noaa_stations.yaml) |
 
 ## Columns
 

--- a/docs/dictionary/usgs/fct_daily_streamflow.md
+++ b/docs/dictionary/usgs/fct_daily_streamflow.md
@@ -9,7 +9,7 @@ Daily streamflow facts pivoted to one row per site per date with key hydrologica
 | Schema | `usgs` |
 | Name | `fct_daily_streamflow` |
 | Kind | `FULL` |
-| Soda contract | [`soda/contracts/usgs/fct_daily_streamflow.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/usgs/fct_daily_streamflow.yaml) |
+| Soda contract | [`soda/contracts/usgs/fct_daily_streamflow.yaml`](https://github.com/Doctacon/databox/blob/main/soda/contracts/usgs/fct_daily_streamflow.yaml) |
 
 ## Columns
 

--- a/docs/dictionary/usgs/fct_daily_streamflow.md
+++ b/docs/dictionary/usgs/fct_daily_streamflow.md
@@ -1,0 +1,56 @@
+# usgs.fct_daily_streamflow
+
+Daily streamflow facts pivoted to one row per site per date with key hydrological metrics
+
+## Overview
+
+| Field | Value |
+| --- | --- |
+| Schema | `usgs` |
+| Name | `fct_daily_streamflow` |
+| Kind | `FULL` |
+| Soda contract | [`soda/contracts/usgs/fct_daily_streamflow.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/usgs/fct_daily_streamflow.yaml) |
+
+## Columns
+
+| Column | Type | Checks | Notes |
+| --- | --- | --- | --- |
+| `discharge_7d_avg_cfs` | `DOUBLE` | — | — |
+| `discharge_cfs` | `UNKNOWN` | — | — |
+| `drainage_area_sqmi` | `UNKNOWN` | — | — |
+| `first_loaded_at` | `TIMESTAMP` | — | — |
+| `gage_height_ft` | `UNKNOWN` | — | — |
+| `huc_cd` | `UNKNOWN` | — | — |
+| `last_loaded_at` | `TIMESTAMP` | — | — |
+| `last_updated_at` | `TIMESTAMP` | — | — |
+| `latitude` | `UNKNOWN` | — | — |
+| `longitude` | `UNKNOWN` | — | — |
+| `observation_date` | `DATE` | missing (must_be=0) | — |
+| `parameter_count` | `BIGINT` | — | — |
+| `site_name` | `UNKNOWN` | — | — |
+| `site_no` | `UNKNOWN` | missing (must_be=0) | — |
+| `state_cd` | `UNKNOWN` | — | — |
+| `water_temp_c` | `UNKNOWN` | — | — |
+| `water_temp_f` | `DOUBLE` | — | — |
+
+## Table-level checks
+
+- **row_count** — must_be_greater_than=0
+- **freshness** — column=last_updated_at, threshold={'unit': 'hour', 'must_be_less_than': 25}
+
+## Lineage
+
+**Upstream**
+
+- [`usgs_staging.stg_usgs_daily_values`](../usgs_staging/stg_usgs_daily_values.md)
+- [`usgs_staging.stg_usgs_sites`](../usgs_staging/stg_usgs_sites.md)
+
+**Downstream**
+
+- [`usgs.int_streamflow_by_h3_day`](int_streamflow_by_h3_day.md)
+
+## Example query
+
+```sql
+SELECT * FROM usgs.fct_daily_streamflow LIMIT 100;
+```

--- a/docs/dictionary/usgs/int_streamflow_by_h3_day.md
+++ b/docs/dictionary/usgs/int_streamflow_by_h3_day.md
@@ -1,0 +1,43 @@
+# usgs.int_streamflow_by_h3_day
+
+Daily USGS streamflow assigned to each H3 cell in the bird-observation universe via nearest-gauge join. Cell-to-gauge mapping is computed once; daily values join in after. H3 resolution 6 matches ebird.int_observations_by_h3_day.
+
+## Overview
+
+| Field | Value |
+| --- | --- |
+| Schema | `usgs` |
+| Name | `int_streamflow_by_h3_day` |
+| Kind | `FULL` |
+| Soda contract | _none_ |
+
+## Columns
+
+| Column | Type | Checks | Notes |
+| --- | --- | --- | --- |
+| `h3_cell` | `UNKNOWN` | — | — |
+| `last_loaded_at` | `TIMESTAMP` | — | — |
+| `mean_discharge_cfs` | `UNKNOWN` | — | — |
+| `mean_gage_height_ft` | `UNKNOWN` | — | — |
+| `mean_water_temp_c` | `UNKNOWN` | — | — |
+| `nearest_gauge_distance_miles` | `DOUBLE` | — | — |
+| `nearest_gauge_id` | `UNKNOWN` | — | — |
+| `observation_date` | `DATE` | — | — |
+
+## Lineage
+
+**Upstream**
+
+- [`ebird.int_observations_by_h3_day`](../ebird/int_observations_by_h3_day.md)
+- [`usgs.fct_daily_streamflow`](fct_daily_streamflow.md)
+- [`usgs_staging.stg_usgs_sites`](../usgs_staging/stg_usgs_sites.md)
+
+**Downstream**
+
+- [`analytics.fct_species_environment_daily`](../analytics/fct_species_environment_daily.md)
+
+## Example query
+
+```sql
+SELECT * FROM usgs.int_streamflow_by_h3_day LIMIT 100;
+```

--- a/docs/dictionary/usgs_staging/stg_usgs_daily_values.md
+++ b/docs/dictionary/usgs_staging/stg_usgs_daily_values.md
@@ -9,7 +9,7 @@ Staging model for USGS daily streamflow and gage observations
 | Schema | `usgs_staging` |
 | Name | `stg_usgs_daily_values` |
 | Kind | `FULL` |
-| Soda contract | [`soda/contracts/usgs_staging/stg_usgs_daily_values.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/usgs_staging/stg_usgs_daily_values.yaml) |
+| Soda contract | [`soda/contracts/usgs_staging/stg_usgs_daily_values.yaml`](https://github.com/Doctacon/databox/blob/main/soda/contracts/usgs_staging/stg_usgs_daily_values.yaml) |
 
 ## Columns
 

--- a/docs/dictionary/usgs_staging/stg_usgs_daily_values.md
+++ b/docs/dictionary/usgs_staging/stg_usgs_daily_values.md
@@ -1,0 +1,50 @@
+# usgs_staging.stg_usgs_daily_values
+
+Staging model for USGS daily streamflow and gage observations
+
+## Overview
+
+| Field | Value |
+| --- | --- |
+| Schema | `usgs_staging` |
+| Name | `stg_usgs_daily_values` |
+| Kind | `FULL` |
+| Soda contract | [`soda/contracts/usgs_staging/stg_usgs_daily_values.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/usgs_staging/stg_usgs_daily_values.yaml) |
+
+## Columns
+
+| Column | Type | Checks | Notes |
+| --- | --- | --- | --- |
+| `latitude` | `UNKNOWN` | — | — |
+| `loaded_at` | `TIMESTAMP` | — | — |
+| `longitude` | `UNKNOWN` | — | — |
+| `observation_date` | `DATE` | missing (must_be=0) | — |
+| `parameter_cd` | `UNKNOWN` | missing (must_be=0) | — |
+| `parameter_name` | `UNKNOWN` | — | — |
+| `qualifier` | `UNKNOWN` | — | — |
+| `site_name` | `UNKNOWN` | — | — |
+| `site_no` | `UNKNOWN` | missing (must_be=0) | — |
+| `state_cd` | `UNKNOWN` | — | — |
+| `unit_cd` | `UNKNOWN` | — | — |
+| `value` | `UNKNOWN` | — | — |
+
+## Table-level checks
+
+- **row_count** — must_be_greater_than=0
+- **freshness** — column=loaded_at, threshold={'unit': 'hour', 'must_be_less_than': 25}
+
+## Lineage
+
+**Upstream**
+
+- `main.daily_values` (external)
+
+**Downstream**
+
+- [`usgs.fct_daily_streamflow`](../usgs/fct_daily_streamflow.md)
+
+## Example query
+
+```sql
+SELECT * FROM usgs_staging.stg_usgs_daily_values LIMIT 100;
+```

--- a/docs/dictionary/usgs_staging/stg_usgs_sites.md
+++ b/docs/dictionary/usgs_staging/stg_usgs_sites.md
@@ -1,0 +1,51 @@
+# usgs_staging.stg_usgs_sites
+
+Staging model for USGS monitoring site metadata
+
+## Overview
+
+| Field | Value |
+| --- | --- |
+| Schema | `usgs_staging` |
+| Name | `stg_usgs_sites` |
+| Kind | `FULL` |
+| Soda contract | [`soda/contracts/usgs_staging/stg_usgs_sites.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/usgs_staging/stg_usgs_sites.yaml) |
+
+## Columns
+
+| Column | Type | Checks | Notes |
+| --- | --- | --- | --- |
+| `begin_date` | `UNKNOWN` | — | — |
+| `county_cd` | `UNKNOWN` | — | — |
+| `drainage_area_sqmi` | `UNKNOWN` | — | — |
+| `end_date` | `UNKNOWN` | — | — |
+| `huc_cd` | `UNKNOWN` | — | — |
+| `latitude` | `UNKNOWN` | — | — |
+| `loaded_at` | `TIMESTAMP` | — | — |
+| `longitude` | `UNKNOWN` | — | — |
+| `site_name` | `UNKNOWN` | — | — |
+| `site_no` | `UNKNOWN` | missing (must_be=0) | — |
+| `site_type` | `UNKNOWN` | — | — |
+| `state_cd` | `UNKNOWN` | — | — |
+
+## Table-level checks
+
+- **row_count** — must_be_greater_than=0
+- **freshness** — column=loaded_at, threshold={'unit': 'hour', 'must_be_less_than': 25}
+
+## Lineage
+
+**Upstream**
+
+- `main.sites` (external)
+
+**Downstream**
+
+- [`usgs.fct_daily_streamflow`](../usgs/fct_daily_streamflow.md)
+- [`usgs.int_streamflow_by_h3_day`](../usgs/int_streamflow_by_h3_day.md)
+
+## Example query
+
+```sql
+SELECT * FROM usgs_staging.stg_usgs_sites LIMIT 100;
+```

--- a/docs/dictionary/usgs_staging/stg_usgs_sites.md
+++ b/docs/dictionary/usgs_staging/stg_usgs_sites.md
@@ -9,7 +9,7 @@ Staging model for USGS monitoring site metadata
 | Schema | `usgs_staging` |
 | Name | `stg_usgs_sites` |
 | Kind | `FULL` |
-| Soda contract | [`soda/contracts/usgs_staging/stg_usgs_sites.yaml`](https://github.com/crlough/databox/blob/main/soda/contracts/usgs_staging/stg_usgs_sites.yaml) |
+| Soda contract | [`soda/contracts/usgs_staging/stg_usgs_sites.yaml`](https://github.com/Doctacon/databox/blob/main/soda/contracts/usgs_staging/stg_usgs_sites.yaml) |
 
 ## Columns
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,38 @@
+# Databox
+
+Dataset-agnostic single-operator data platform. Ingests bird, weather, and
+streamflow sources with dlt, transforms with SQLMesh, validates with Soda
+contracts, and orchestrates with Dagster on DuckDB / MotherDuck.
+
+## What's here
+
+- **[Data dictionary](dictionary/index.md)** — every model, its columns and
+  types, the Soda contract in effect, and direct lineage. Auto-generated
+  from SQLMesh and Soda metadata.
+- **[Lineage](dictionary/lineage.md)** — full model dependency graph rendered
+  with Mermaid. Each node links to its dictionary page.
+- **[Metrics](metrics.md)** — semantic metrics layer over the flagship mart
+  (`analytics.fct_species_environment_daily`).
+- **[Analytics examples](analytics-examples.md)** — representative queries
+  the flagship mart supports.
+- **[Contracts](contracts.md)** — Soda quality contract conventions.
+- **[Incremental loading](incremental-loading.md)** — dlt incremental and
+  SQLMesh incremental-by-time notes.
+
+## Case study
+
+The case-study README (architecture walkthrough and decision record index) is
+tracked in `ticket:architecture-docs` and will be linked from here once
+published.
+
+## Regenerate
+
+Everything under [dictionary/](dictionary/index.md) is generated from the repo — do
+not hand-edit. Rebuild with:
+
+```bash
+uv run python scripts/generate_docs.py
+```
+
+Target runtime: under 30 seconds; observed runtime: ~1–2 seconds for the
+current model set.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -2,7 +2,7 @@
 
 Canonical metric definitions over `analytics.fct_species_environment_daily`.
 Every metric below is registered in
-[`transforms/main/metrics/flagship.sql`](../transforms/main/metrics/flagship.sql)
+[`transforms/main/metrics/flagship.sql`](https://github.com/crlough/databox/blob/main/transforms/main/metrics/flagship.sql)
 and is the single source of truth — if you see metric math duplicated
 elsewhere, that duplication is a bug.
 
@@ -86,6 +86,6 @@ print(available_metrics())
 ## Design Decision
 
 See
-[`.loom/research/20260421-semantic-metrics-approach.md`](../.loom/research/20260421-semantic-metrics-approach.md)
+[`.loom/research/20260421-semantic-metrics-approach.md`](https://github.com/crlough/databox/blob/main/.loom/research/20260421-semantic-metrics-approach.md)
 for why SQLMesh native metrics beat MetricFlow and flat `analytics.metric_*`
 views for this project.

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -2,7 +2,7 @@
 
 Canonical metric definitions over `analytics.fct_species_environment_daily`.
 Every metric below is registered in
-[`transforms/main/metrics/flagship.sql`](https://github.com/crlough/databox/blob/main/transforms/main/metrics/flagship.sql)
+[`transforms/main/metrics/flagship.sql`](https://github.com/Doctacon/databox/blob/main/transforms/main/metrics/flagship.sql)
 and is the single source of truth — if you see metric math duplicated
 elsewhere, that duplication is a bug.
 
@@ -86,6 +86,6 @@ print(available_metrics())
 ## Design Decision
 
 See
-[`.loom/research/20260421-semantic-metrics-approach.md`](https://github.com/crlough/databox/blob/main/.loom/research/20260421-semantic-metrics-approach.md)
+[`.loom/research/20260421-semantic-metrics-approach.md`](https://github.com/Doctacon/databox/blob/main/.loom/research/20260421-semantic-metrics-approach.md)
 for why SQLMesh native metrics beat MetricFlow and flat `analytics.metric_*`
 views for this project.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,64 @@
+site_name: Databox Data Dictionary
+site_description: Auto-generated data dictionary and lineage for the Databox platform.
+site_url: https://crlough.github.io/databox/
+repo_url: https://github.com/crlough/databox
+repo_name: crlough/databox
+edit_uri: ""
+
+docs_dir: docs
+
+theme:
+  name: material
+  features:
+    - navigation.instant
+    - navigation.sections
+    - navigation.expand
+    - navigation.indexes
+    - navigation.top
+    - content.code.copy
+    - search.highlight
+    - search.suggest
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: teal
+      accent: teal
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: teal
+      accent: teal
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - md_in_html
+  - pymdownx.details
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+  - pymdownx.tabbed:
+      alternate_style: true
+  - tables
+  - toc:
+      permalink: true
+
+plugins:
+  - search
+
+nav:
+  - Home: index.md
+  - Data dictionary:
+      - Overview: dictionary/index.md
+      - Lineage: dictionary/lineage.md
+  - Analytics examples: analytics-examples.md
+  - Metrics: metrics.md
+  - Contracts: contracts.md
+  - Incremental loading: incremental-loading.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: Databox Data Dictionary
 site_description: Auto-generated data dictionary and lineage for the Databox platform.
-site_url: https://crlough.github.io/databox/
-repo_url: https://github.com/crlough/databox
-repo_name: crlough/databox
+site_url: https://doctacon.github.io/databox/
+repo_url: https://github.com/Doctacon/databox
+repo_name: Doctacon/databox
 edit_uri: ""
 
 docs_dir: docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ dev = [
     "types-PyYAML>=6.0",
     "pytest-recording>=0.13",
     "syrupy>=4.0",
+    "mkdocs>=1.6.1",
+    "mkdocs-material>=9.7.6",
 ]
 
 [tool.mypy]

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -28,7 +28,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 TRANSFORMS_PATH = REPO_ROOT / "transforms" / "main"
 SODA_ROOT = REPO_ROOT / "soda" / "contracts"
 OUT_ROOT = REPO_ROOT / "docs" / "dictionary"
-REPO_BLOB_URL = "https://github.com/crlough/databox/blob/main"
+REPO_BLOB_URL = "https://github.com/Doctacon/databox/blob/main"
 
 SCHEMA_DESCRIPTIONS = {
     "analytics": "Cross-domain marts that join bird, weather, and streamflow signals.",

--- a/scripts/generate_docs.py
+++ b/scripts/generate_docs.py
@@ -1,0 +1,362 @@
+"""Generate the data-dictionary MkDocs site from SQLMesh + Soda metadata.
+
+Walks the SQLMesh project at ``transforms/main`` via ``sqlmesh.Context`` and
+the Soda contract tree at ``soda/contracts``. Emits one Markdown page per
+model plus a global Mermaid lineage page under ``docs/dictionary/``.
+
+The generator is side-effect-free and deterministic: sorted ordering
+everywhere, idempotent re-writes, no network calls. Intended to run in
+<30 seconds in CI and locally.
+
+Usage:
+    uv run python scripts/generate_docs.py
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+from sqlmesh import Context
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TRANSFORMS_PATH = REPO_ROOT / "transforms" / "main"
+SODA_ROOT = REPO_ROOT / "soda" / "contracts"
+OUT_ROOT = REPO_ROOT / "docs" / "dictionary"
+REPO_BLOB_URL = "https://github.com/crlough/databox/blob/main"
+
+SCHEMA_DESCRIPTIONS = {
+    "analytics": "Cross-domain marts that join bird, weather, and streamflow signals.",
+    "ebird": "eBird bird-observation domain — intermediate and mart models.",
+    "ebird_staging": "eBird staging views — raw dlt loads with column renames only.",
+    "noaa": "NOAA weather domain — intermediate and mart models.",
+    "noaa_staging": "NOAA staging views — raw dlt loads with column renames only.",
+    "usgs": "USGS streamflow domain — intermediate and mart models.",
+    "usgs_staging": "USGS staging views — raw dlt loads with column renames only.",
+}
+
+
+@dataclass(frozen=True)
+class SodaCheck:
+    column: str
+    kind: str
+    detail: str
+
+
+@dataclass
+class SodaContract:
+    dataset: str
+    column_types: dict[str, str]
+    column_checks: dict[str, list[SodaCheck]]
+    table_checks: list[SodaCheck]
+    path: Path
+
+
+def load_soda_contracts() -> dict[str, SodaContract]:
+    """Parse every Soda contract under soda/contracts/ keyed by model fqn."""
+    contracts: dict[str, SodaContract] = {}
+    for path in sorted(SODA_ROOT.rglob("*.yaml")):
+        doc = yaml.safe_load(path.read_text())
+        if not isinstance(doc, dict) or "dataset" not in doc:
+            continue
+        dataset = doc["dataset"]
+        parts = dataset.split("/")
+        if len(parts) != 3:
+            continue
+        _, schema, name = parts
+        fqn = f'"databox"."{schema}"."{name}"'
+
+        col_types: dict[str, str] = {}
+        col_checks: dict[str, list[SodaCheck]] = {}
+        for col in doc.get("columns") or []:
+            cname = col.get("name")
+            if not cname:
+                continue
+            col_types[cname] = col.get("data_type", "")
+            checks: list[SodaCheck] = []
+            for check in col.get("checks") or []:
+                checks.extend(_flatten_check(check, cname))
+            if checks:
+                col_checks[cname] = checks
+
+        table_checks: list[SodaCheck] = []
+        for check in doc.get("checks") or []:
+            table_checks.extend(_flatten_check(check, column="(table)"))
+
+        contracts[fqn] = SodaContract(
+            dataset=dataset,
+            column_types=col_types,
+            column_checks=col_checks,
+            table_checks=table_checks,
+            path=path.relative_to(REPO_ROOT),
+        )
+    return contracts
+
+
+def _flatten_check(check: Any, column: str) -> list[SodaCheck]:
+    if not isinstance(check, dict):
+        return []
+    out: list[SodaCheck] = []
+    for kind, body in check.items():
+        detail = _fmt_check_body(body)
+        out.append(SodaCheck(column=column, kind=kind, detail=detail))
+    return out
+
+
+def _fmt_check_body(body: Any) -> str:
+    if body is None:
+        return ""
+    if isinstance(body, dict):
+        return ", ".join(f"{k}={v}" for k, v in body.items())
+    return str(body)
+
+
+def build_context() -> Context:
+    os.environ.setdefault("DATABOX_GATEWAY", "local")
+    return Context(paths=[str(TRANSFORMS_PATH)], gateway=os.environ["DATABOX_GATEWAY"])
+
+
+def short_name(fqn: str) -> str:
+    """Return ``schema.name`` from a fully-qualified ``"db"."schema"."name"``."""
+    clean = fqn.replace('"', "")
+    parts = clean.split(".")
+    if len(parts) >= 2:
+        return ".".join(parts[-2:])
+    return clean
+
+
+def page_path_for(fqn: str) -> Path:
+    """docs/dictionary/<schema>/<name>.md — deterministic path per model."""
+    short = short_name(fqn)
+    schema, _, name = short.partition(".")
+    return OUT_ROOT / schema / f"{name}.md"
+
+
+def relative_model_link(from_fqn: str, to_fqn: str) -> str:
+    """Relative markdown link from one model page to another."""
+    src = page_path_for(from_fqn).parent
+    dst = page_path_for(to_fqn)
+    try:
+        return os.path.relpath(dst, src)
+    except ValueError:
+        return str(dst)
+
+
+def render_model_page(
+    ctx: Context,
+    fqn: str,
+    contracts: dict[str, SodaContract],
+) -> str:
+    model = ctx.models[fqn]
+    short = short_name(fqn)
+    schema, _, name = short.partition(".")
+
+    upstream = sorted(getattr(model, "depends_on", None) or set())
+    downstream = sorted(
+        d for d, m in ctx.models.items() if fqn in (getattr(m, "depends_on", None) or set())
+    )
+
+    contract = contracts.get(fqn)
+
+    lines: list[str] = []
+    lines.append(f"# {short}")
+    lines.append("")
+    desc = (getattr(model, "description", None) or "").strip()
+    lines.append(desc if desc else "_No model-level description._")
+    lines.append("")
+
+    lines.append("## Overview")
+    lines.append("")
+    lines.append("| Field | Value |")
+    lines.append("| --- | --- |")
+    lines.append(f"| Schema | `{schema}` |")
+    lines.append(f"| Name | `{name}` |")
+    lines.append(f"| Kind | `{model.kind.name}` |")
+    grains = getattr(model, "grains", None) or []
+    if grains:
+        grain_str = ", ".join(f"`{g.sql(dialect='duckdb')}`" for g in grains)
+        lines.append(f"| Grain | {grain_str} |")
+    if contract:
+        url = f"{REPO_BLOB_URL}/{contract.path}"
+        lines.append(f"| Soda contract | [`{contract.path}`]({url}) |")
+    else:
+        lines.append("| Soda contract | _none_ |")
+    lines.append("")
+
+    lines.append("## Columns")
+    lines.append("")
+    lines.append("| Column | Type | Checks | Notes |")
+    lines.append("| --- | --- | --- | --- |")
+    col_descriptions = getattr(model, "column_descriptions", None) or {}
+    cols = getattr(model, "columns_to_types", None) or {}
+    all_col_names = set(cols.keys())
+    if contract:
+        all_col_names.update(contract.column_types.keys())
+    for col_name in sorted(all_col_names):
+        sql_type = cols[col_name].sql(dialect="duckdb") if col_name in cols else "UNKNOWN"
+        soda_type = contract.column_types.get(col_name, "") if contract else ""
+        if sql_type == "UNKNOWN" and soda_type:
+            dtype = soda_type
+        else:
+            dtype = sql_type
+        checks = []
+        if contract:
+            for c in contract.column_checks.get(col_name, []):
+                checks.append(f"{c.kind}" + (f" ({c.detail})" if c.detail else ""))
+        note = (col_descriptions.get(col_name) or "").strip().replace("|", "\\|")
+        lines.append(f"| `{col_name}` | `{dtype}` | {', '.join(checks) or '—'} | {note or '—'} |")
+    if contract and contract.table_checks:
+        lines.append("")
+        lines.append("## Table-level checks")
+        lines.append("")
+        for c in contract.table_checks:
+            suffix = f" — {c.detail}" if c.detail else ""
+            lines.append(f"- **{c.kind}**{suffix}")
+    lines.append("")
+
+    lines.append("## Lineage")
+    lines.append("")
+    if upstream:
+        lines.append("**Upstream**")
+        lines.append("")
+        for u in upstream:
+            if u in ctx.models:
+                lines.append(f"- [`{short_name(u)}`]({relative_model_link(fqn, u)})")
+            else:
+                lines.append(f"- `{short_name(u)}` (external)")
+        lines.append("")
+    if downstream:
+        lines.append("**Downstream**")
+        lines.append("")
+        for d in downstream:
+            if d in ctx.models:
+                lines.append(f"- [`{short_name(d)}`]({relative_model_link(fqn, d)})")
+        lines.append("")
+    if not upstream and not downstream:
+        lines.append("_No declared dependencies._")
+        lines.append("")
+
+    lines.append("## Example query")
+    lines.append("")
+    lines.append("```sql")
+    lines.append(f"SELECT * FROM {schema}.{name} LIMIT 100;")
+    lines.append("```")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_lineage_page(ctx: Context) -> str:
+    """One Mermaid graph of all internal models; nodes link to their pages."""
+    models = sorted(ctx.models.keys())
+    node_ids: dict[str, str] = {}
+    for i, fqn in enumerate(models):
+        node_ids[fqn] = f"n{i}"
+
+    lines: list[str] = []
+    lines.append("# Lineage")
+    lines.append("")
+    lines.append(
+        "Full model dependency graph across all SQLMesh projects. "
+        "Each node links to its data-dictionary page."
+    )
+    lines.append("")
+    lines.append("```mermaid")
+    lines.append("graph LR")
+    for fqn in models:
+        lines.append(f'    {node_ids[fqn]}["{short_name(fqn)}"]')
+    for fqn in models:
+        direct_deps = getattr(ctx.models[fqn], "depends_on", None) or set()
+        for up in sorted(direct_deps):
+            if up in node_ids:
+                lines.append(f"    {node_ids[up]} --> {node_ids[fqn]}")
+    lines.append("")
+    for fqn in models:
+        short = short_name(fqn)
+        schema, _, name = short.partition(".")
+        href = f"{schema}/{name}.md"
+        lines.append(f'    click {node_ids[fqn]} "{href}"')
+    lines.append("```")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def render_index_page(ctx: Context, contracts: dict[str, SodaContract]) -> str:
+    by_schema: dict[str, list[str]] = {}
+    for fqn in ctx.models:
+        short = short_name(fqn)
+        schema, _, _ = short.partition(".")
+        by_schema.setdefault(schema, []).append(fqn)
+
+    lines: list[str] = []
+    lines.append("# Data dictionary")
+    lines.append("")
+    lines.append(
+        "Auto-generated from SQLMesh model metadata and Soda contracts. "
+        "Regenerate with `uv run python scripts/generate_docs.py`."
+    )
+    lines.append("")
+    lines.append(f"- **Models:** {len(ctx.models)}")
+    lines.append(f"- **Soda contracts:** {len(contracts)}")
+    lines.append("- **Lineage:** [browse the dependency graph](lineage.md)")
+    lines.append("")
+
+    for schema in sorted(by_schema):
+        desc = SCHEMA_DESCRIPTIONS.get(schema, "")
+        lines.append(f"## `{schema}`")
+        lines.append("")
+        if desc:
+            lines.append(desc)
+            lines.append("")
+        lines.append("| Model | Contract | Description |")
+        lines.append("| --- | --- | --- |")
+        for fqn in sorted(by_schema[schema]):
+            short = short_name(fqn)
+            _, _, name = short.partition(".")
+            model = ctx.models[fqn]
+            model_desc = (getattr(model, "description", None) or "").strip()
+            first_sentence = model_desc.split(". ")[0] if model_desc else "—"
+            has_contract = "yes" if fqn in contracts else "—"
+            link = f"{schema}/{name}.md"
+            lines.append(f"| [`{short}`]({link}) | {has_contract} | {first_sentence} |")
+        lines.append("")
+    return "\n".join(lines)
+
+
+def write_file(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if not content.endswith("\n"):
+        content = content + "\n"
+    path.write_text(content)
+
+
+def main() -> int:
+    if OUT_ROOT.exists():
+        shutil.rmtree(OUT_ROOT)
+    OUT_ROOT.mkdir(parents=True)
+
+    ctx = build_context()
+    contracts = load_soda_contracts()
+
+    n_pages = 0
+    for fqn in sorted(ctx.models):
+        page = render_model_page(ctx, fqn, contracts)
+        write_file(page_path_for(fqn), page)
+        n_pages += 1
+
+    write_file(OUT_ROOT / "lineage.md", render_lineage_page(ctx))
+    write_file(OUT_ROOT / "index.md", render_index_page(ctx, contracts))
+
+    print(
+        f"Generated {n_pages} model pages + lineage + index "
+        f"under {OUT_ROOT.relative_to(REPO_ROOT)}/"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/uv.lock
+++ b/uv.lock
@@ -84,12 +84,35 @@ wheels = [
 ]
 
 [[package]]
+name = "babel"
+version = "2.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/b2/51899539b6ceeeb420d40ed3cd4b7a40519404f9baf3d4ac99dc413a834b/babel-2.18.0.tar.gz", hash = "sha256:b80b99a14bd085fcacfa15c9165f651fbb3406e66cc603abf11c5750937c992d", size = 9959554, upload-time = "2026-02-01T12:30:56.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/f5/21d2de20e8b8b0408f0681956ca2c69f1320a3848ac50e6e7f39c6159675/babel-2.18.0-py3-none-any.whl", hash = "sha256:e2b422b277c2b9a9630c1d7903c2a00d0830c409c59ac8cae9081c92f1aeba35", size = 10196845, upload-time = "2026-02-01T12:30:53.445Z" },
+]
+
+[[package]]
 name = "backoff"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
+]
+
+[[package]]
+name = "backrefs"
+version = "6.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/a6/e325ec73b638d3ede4421b5445d4a0b8b219481826cc079d510100af356c/backrefs-6.2.tar.gz", hash = "sha256:f44ff4d48808b243b6c0cdc6231e22195c32f77046018141556c66f8bab72a49", size = 7012303, upload-time = "2026-02-16T19:10:15.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/39/3765df263e08a4df37f4f43cb5aa3c6c17a4bdd42ecfe841e04c26037171/backrefs-6.2-py310-none-any.whl", hash = "sha256:0fdc7b012420b6b144410342caeb8adc54c6866cf12064abc9bb211302e496f8", size = 381075, upload-time = "2026-02-16T19:10:04.322Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/f0/35240571e1b67ffb19dafb29ab34150b6f59f93f717b041082cdb1bfceb1/backrefs-6.2-py311-none-any.whl", hash = "sha256:08aa7fae530c6b2361d7bdcbda1a7c454e330cc9dbcd03f5c23205e430e5c3be", size = 392874, upload-time = "2026-02-16T19:10:06.314Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/63/77e8c9745b4d227cce9f5e0a6f68041278c5f9b18588b35905f5f19c1beb/backrefs-6.2-py312-none-any.whl", hash = "sha256:c3f4b9cb2af8cda0d87ab4f57800b57b95428488477be164dd2b47be54db0c90", size = 398787, upload-time = "2026-02-16T19:10:08.274Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/71/c754b1737ad99102e03fa3235acb6cb6d3ac9d6f596cbc3e5f236705abd8/backrefs-6.2-py313-none-any.whl", hash = "sha256:12df81596ab511f783b7d87c043ce26bc5b0288cf3bb03610fe76b8189282b2b", size = 400747, upload-time = "2026-02-16T19:10:09.791Z" },
+    { url = "https://files.pythonhosted.org/packages/af/75/be12ba31a6eb20dccef2320cd8ccb3f7d9013b68ba4c70156259fee9e409/backrefs-6.2-py314-none-any.whl", hash = "sha256:e5f805ae09819caa1aa0623b4a83790e7028604aa2b8c73ba602c4454e665de7", size = 412602, upload-time = "2026-02-16T19:10:12.317Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f8/d02f650c47d05034dcd6f9c8cf94f39598b7a89c00ecda0ecb2911bc27e9/backrefs-6.2-py39-none-any.whl", hash = "sha256:664e33cd88c6840b7625b826ecf2555f32d491800900f5a541f772c485f7cda7", size = 381077, upload-time = "2026-02-16T19:10:13.74Z" },
 ]
 
 [[package]]
@@ -419,6 +442,8 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "faker" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -442,6 +467,8 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "faker", specifier = ">=30.0" },
+    { name = "mkdocs", specifier = ">=1.6.1" },
+    { name = "mkdocs-material", specifier = ">=9.7.6" },
     { name = "mypy", specifier = ">=1.0" },
     { name = "pre-commit", specifier = ">=4.0" },
     { name = "pytest", specifier = ">=8.0" },
@@ -687,6 +714,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/8b/02/0835e6ab9cfc03916fe3f78c0956cfcdb6ff2669ffa6651065d5ebf7fc98/fsspec-2025.7.0.tar.gz", hash = "sha256:786120687ffa54b8283d942929540d8bc5ccfa820deb555a2b5d0ed2b737bf58", size = 304432, upload-time = "2025-07-15T16:05:21.19Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2f/e0/014d5d9d7a4564cf1c40b5039bc882db69fd881111e03ab3657ac0b218e2/fsspec-2025.7.0-py3-none-any.whl", hash = "sha256:8b012e39f63c7d5f10474de957f3ab793b47b45ae7d39f2fb735f8bbe25c0e21", size = 199597, upload-time = "2025-07-15T16:05:19.529Z" },
+]
+
+[[package]]
+name = "ghp-import"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
 ]
 
 [[package]]
@@ -1179,6 +1218,15 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown"
+version = "3.10.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
+]
+
+[[package]]
 name = "markdown-it-py"
 version = "3.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1247,6 +1295,84 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
+]
+
+[[package]]
+name = "mergedeep"
+version = "1.3.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/41/580bb4006e3ed0361b8151a01d324fb03f420815446c7def45d02f74c270/mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8", size = 4661, upload-time = "2021-02-05T18:55:30.623Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/19/04f9b178c2d8a15b076c8b5140708fa6ffc5601fb6f1e975537072df5b2a/mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307", size = 6354, upload-time = "2021-02-05T18:55:29.583Z" },
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "ghp-import" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mergedeep" },
+    { name = "mkdocs-get-deps" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "pyyaml" },
+    { name = "pyyaml-env-tag" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bc/c6/bbd4f061bd16b378247f12953ffcb04786a618ce5e904b8c5a01a0309061/mkdocs-1.6.1.tar.gz", hash = "sha256:7b432f01d928c084353ab39c57282f29f92136665bdd6abf7c1ec8d822ef86f2", size = 3889159, upload-time = "2024-08-30T12:24:06.899Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/5b/dbc6a8cddc9cfa9c4971d59fb12bb8d42e161b7e7f8cc89e49137c5b279c/mkdocs-1.6.1-py3-none-any.whl", hash = "sha256:db91759624d1647f3f34aa0c3f327dd2601beae39a366d6e064c03468d35c20e", size = 3864451, upload-time = "2024-08-30T12:24:05.054Z" },
+]
+
+[[package]]
+name = "mkdocs-get-deps"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mergedeep" },
+    { name = "platformdirs" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/25/b3cccb187655b9393572bde9b09261d267c3bf2f2cdabe347673be5976a6/mkdocs_get_deps-0.2.2.tar.gz", hash = "sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1", size = 11047, upload-time = "2026-03-10T02:46:33.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/29/744136411e785c4b0b744d5413e56555265939ab3a104c6a4b719dad33fd/mkdocs_get_deps-0.2.2-py3-none-any.whl", hash = "sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650", size = 9555, upload-time = "2026-03-10T02:46:32.256Z" },
+]
+
+[[package]]
+name = "mkdocs-material"
+version = "9.7.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "backrefs" },
+    { name = "colorama" },
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "mkdocs" },
+    { name = "mkdocs-material-extensions" },
+    { name = "paginate" },
+    { name = "pygments" },
+    { name = "pymdown-extensions" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470, upload-time = "2026-03-19T15:41:55.217Z" },
+]
+
+[[package]]
+name = "mkdocs-material-extensions"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
 ]
 
 [[package]]
@@ -1572,6 +1698,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "paginate"
+version = "0.5.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/46/68dde5b6bc00c1296ec6466ab27dddede6aec9af1b99090e1107091b3b84/paginate-0.5.7.tar.gz", hash = "sha256:22bd083ab41e1a8b4f3690544afb2c60c25e5c9a63a30fa2f483f6c60c8e5945", size = 19252, upload-time = "2024-08-25T14:17:24.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/96/04b8e52da071d28f5e21a805b19cb9390aa17a47462ac87f5e2696b9566d/paginate-0.5.7-py2.py3-none-any.whl", hash = "sha256:b885e2af73abcf01d9559fd5216b57ef722f8c42affbb63942377668e35c7591", size = 13746, upload-time = "2024-08-25T14:17:22.55Z" },
 ]
 
 [[package]]
@@ -1971,6 +2106,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pymdown-extensions"
+version = "10.21.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/08/f1c908c581fd11913da4711ea7ba32c0eee40b0190000996bb863b0c9349/pymdown_extensions-10.21.2.tar.gz", hash = "sha256:c3f55a5b8a1d0edf6699e35dcbea71d978d34ff3fa79f3d807b8a5b3fa90fbdc", size = 853922, upload-time = "2026-03-29T15:01:55.233Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/27/a2fc51a4a122dfd1015e921ae9d22fee3d20b0b8080d9a704578bf9deece/pymdown_extensions-10.21.2-py3-none-any.whl", hash = "sha256:5c0fd2a2bea14eb39af8ff284f1066d898ab2187d81b889b75d46d4348c01638", size = 268901, upload-time = "2026-03-29T15:01:53.244Z" },
+]
+
+[[package]]
 name = "pyreadline3"
 version = "3.5.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2117,6 +2265,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/0f/25911a9f080464c59fab9027482f822b86bf0608957a5fcc6eaac85aa515/PyYAML-6.0.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:68ccc6023a3400877818152ad9a1033e3db8625d899c72eacb5a668902e4d652", size = 751597, upload-time = "2024-08-06T20:32:56.985Z" },
     { url = "https://files.pythonhosted.org/packages/14/0d/e2c3b43bbce3cf6bd97c840b46088a3031085179e596d4929729d8d68270/PyYAML-6.0.2-cp313-cp313-win32.whl", hash = "sha256:bc2fa7c6b47d6bc618dd7fb02ef6fdedb1090ec036abab80d4681424b84c1183", size = 140527, upload-time = "2024-08-06T20:33:03.001Z" },
     { url = "https://files.pythonhosted.org/packages/fa/de/02b54f42487e3d3c6efb3f89428677074ca7bf43aae402517bc7cca949f3/PyYAML-6.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:8388ee1976c416731879ac16da0aff3f63b286ffdd57cdeb95f3f2e085687563", size = 156446, upload-time = "2024-08-06T20:33:04.33Z" },
+]
+
+[[package]]
+name = "pyyaml-env-tag"
+version = "1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `scripts/generate_docs.py` walks `sqlmesh.Context` + `soda/contracts/` YAMLs and emits per-model Markdown pages plus a global Mermaid lineage page under `docs/dictionary/`. Deterministic sort, ~1.5s on the current 20-model set.
- MkDocs-Material site (`mkdocs.yml` + `docs/index.md`) with strict-mode clean build.
- `.github/workflows/docs.yaml` rebuilds and deploys to GitHub Pages on every push to `main`.

Closes ticket:data-dictionary-site (phase 2 of initiative:staff-portfolio-readiness).

## Test plan

- [x] `uv run python scripts/generate_docs.py` regenerates 20 model pages + lineage + index in ~1.5s (well under the 30s budget).
- [x] `uv run mkdocs build --strict` — clean.
- [x] `uv run pytest` — 18 passed.
- [x] `uv run ruff check .` + `uv run ruff format --check .` — clean.
- [ ] After merge, Pages workflow deploys site to https://crlough.github.io/databox/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)