### PR TITLE
feat(docs): recruiter-oriented README + 6 backfilled ADRs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Connor Lough
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,199 +1,244 @@
 # Databox
 
 [![CI](https://github.com/Doctacon/databox/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/Doctacon/databox/actions/workflows/ci.yaml)
+[![Docs](https://github.com/Doctacon/databox/actions/workflows/docs.yaml/badge.svg?branch=main)](https://doctacon.github.io/databox/)
+[![Python](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/)
+[![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
-A dataset-agnostic data platform for ingestion, transformation, quality checking, and visualization. Zero-infra local mode (file-based DuckDB) with a one-flag switch to MotherDuck cloud. Orchestrated end-to-end by Dagster.
+A single-operator data platform that ingests three public APIs (eBird,
+NOAA, USGS) into one queryable cross-domain warehouse. Zero always-on
+infra: file-based DuckDB locally, MotherDuck cloud with one environment
+flag. Every layer — ingest, transform, quality, orchestration, semantic
+metrics, data dictionary — is wired end-to-end through the same
+open-source stack.
+
+The project exists to answer one question: *"do species distributions
+shift with same-day weather and streamflow anomalies?"* The platform
+around it exists to answer that question honestly, repeatably, and
+with receipts.
+
+## Evaluate this repo in ten minutes
+
+1. Skim the **System architecture** diagram below.
+2. Skim the **Data flow** diagram below.
+3. Open the **[data dictionary](https://doctacon.github.io/databox/)** —
+   every model, columns, types, Soda checks, lineage.
+4. Read **[ADR-0001 through ADR-0006](docs/adr/)** for the six load-bearing
+   architectural decisions.
+5. Read **[docs/analytics-examples.md](docs/analytics-examples.md)** to see
+   what the cross-domain mart actually answers.
+
+## System architecture
+
+```mermaid
+graph TB
+    subgraph External["External APIs"]
+        ebird_api[eBird API v2]
+        noaa_api[NOAA CDO v2]
+        usgs_api[USGS NWIS]
+    end
+
+    subgraph Ingest["Ingestion · dlt"]
+        ebird_src[ebird source]
+        noaa_src[noaa source]
+        usgs_src[usgs source]
+    end
+
+    subgraph Raw["Raw catalogs · DuckDB / MotherDuck"]
+        raw_ebird[(raw_ebird)]
+        raw_noaa[(raw_noaa)]
+        raw_usgs[(raw_usgs)]
+    end
+
+    subgraph Transform["Transform · SQLMesh"]
+        staging["*_staging views"]
+        marts["ebird / noaa / usgs marts"]
+        analytics["analytics.*  cross-domain marts"]
+        metrics["semantic metrics METRIC()"]
+    end
+
+    subgraph Quality["Quality · Soda Core"]
+        contracts["Soda contracts per model"]
+    end
+
+    subgraph Consumer["Consumers"]
+        dashboard["MotherDuck Dive dashboards"]
+        dict["Data dictionary site (MkDocs)"]
+        notebook["Notebooks via metrics helper"]
+    end
+
+    Orchestrator["Dagster: sole orchestrator<br/>assets · schedules · sensors · asset checks"]
+
+    ebird_api --> ebird_src --> raw_ebird
+    noaa_api --> noaa_src --> raw_noaa
+    usgs_api --> usgs_src --> raw_usgs
+    raw_ebird --> staging
+    raw_noaa --> staging
+    raw_usgs --> staging
+    staging --> marts
+    marts --> analytics
+    analytics --> metrics
+    analytics --> contracts
+    marts --> contracts
+    analytics --> dashboard
+    analytics --> dict
+    metrics --> notebook
+
+    Orchestrator -.materializes.-> ebird_src
+    Orchestrator -.materializes.-> noaa_src
+    Orchestrator -.materializes.-> usgs_src
+    Orchestrator -.materializes.-> staging
+    Orchestrator -.materializes.-> marts
+    Orchestrator -.materializes.-> analytics
+    Orchestrator -.asset-checks.-> contracts
+```
+
+## Data flow
+
+```mermaid
+flowchart LR
+    A[API responses<br/>JSON] -->|dlt incremental| B[raw_*<br/>append-only tables]
+    B -->|SQLMesh stg_* views| C[*_staging<br/>renames + type coercion]
+    C -->|SQLMesh int_* models| D[int_*<br/>H3 cell + day grain]
+    D -->|SQLMesh fct_* / dim_*| E[source marts<br/>ebird / noaa / usgs]
+    E -->|cross-domain joins| F[analytics.fct_species_environment_daily<br/>species × H3 × day]
+    F -->|METRIC DDL| G[semantic metrics<br/>richness · intensity · anomalies]
+    F -->|Soda asset check| H{quality gate}
+    H -->|pass| I[Dive dashboards + notebooks]
+    H -->|fail| J[block downstream · surface in Dagster]
+```
+
+## What this demonstrates
+
+Each claim is backed by a ticket and its evidence, not just prose.
+
+| Capability | How it shows up | Evidence |
+|---|---|---|
+| **Cross-domain modeling** — joining bird, weather, and streamflow at a shared spatial grain | `analytics.fct_species_environment_daily` keyed on `(species_code, h3_cell, obs_date)`, H3 cells resolve spatial joins across domains | [ticket:flagship-cross-domain-mart](.loom/tickets/20260420-7g33iy2i-flagship-cross-domain-mart.md) · [example queries](docs/analytics-examples.md) |
+| **Semantic metrics layer** — one canonical SQL definition per KPI | Seven metrics in `transforms/main/metrics/flagship.sql`, queryable by name via `resolve_metric_query()` | [ticket:semantic-metrics-layer](.loom/tickets/20260420-ah4djnga-semantic-metrics-layer.md) · [metrics docs](docs/metrics.md) · [design record](.loom/research/20260421-semantic-metrics-approach.md) |
+| **Contract-based quality** — every model has a Soda contract gated as a Dagster asset check | `soda/contracts/` + Soda asset checks that block downstream materialization on failure | [ticket:observability-pass](.loom/tickets/20260420-wvp3m9gt-observability-pass.md) · [contracts doc](docs/contracts.md) |
+| **Schema-contract CI gate** — breaking changes to contracts require explicit opt-in | `scripts/schema_gate.py` runs on PRs, blocks column drops / type narrowings without `accept-breaking-change` marker | [ticket:schema-contract-ci](.loom/tickets/20260420-bsha1b91-schema-contract-ci.md) |
+| **Auto-generated data dictionary** — every model's columns, types, checks, and lineage discoverable without cloning | [doctacon.github.io/databox](https://doctacon.github.io/databox/), regenerated from `sqlmesh.Context` + Soda YAML | [ticket:data-dictionary-site](.loom/tickets/20260420-2ikjh1e2-data-dictionary-site.md) |
+| **Idempotent incremental ingest** — reruns do not double-count | `write_disposition='merge'` on the right resources, primary keys declared, documented contract | [ticket:incremental-load-audit](.loom/tickets/20260420-c1ogpdel-incremental-load-audit.md) · [incremental-loading doc](docs/incremental-loading.md) |
+| **Portable local ↔ cloud** — identical SQL, environment-variable switch | `DATABOX_BACKEND=local` vs `=motherduck`; gateways mirror; settings return file paths vs `md:` URIs transparently | [ADR-0006](docs/adr/0006-motherduck-as-cloud-path.md) |
+| **Single orchestration surface** — Dagster owns every run, no CLI drift | Every asset (ingest, transform, quality) visible in one DAG; `task` targets are thin wrappers | [ADR-0005](docs/adr/0005-dagster-as-sole-orchestrator.md) |
 
 ## Stack
 
-- **dlt** — Python-native data ingestion with auto-schema detection
-- **sqlmesh** — SQL-based transformations with version control and testing
-- **DuckDB** — Embedded analytical database (local) or MotherDuck (cloud)
-- **Dagster** — Orchestration + unified entrypoint (assets, schedules, lineage, sensors)
-- **Soda Core** — Contract-based data quality checks (run as asset checks)
-- **Streamlit** — Data explorer app
+- **[dlt](https://dlthub.com/)** — Python-native ingestion, auto-schema inference
+- **[SQLMesh](https://sqlmesh.com/)** — SQL transforms with virtual environments, native metrics, column-level change detection (see [ADR-0002](docs/adr/0002-sqlmesh-over-dbt.md))
+- **[DuckDB](https://duckdb.org/)** — embedded analytical warehouse (see [ADR-0001](docs/adr/0001-duckdb-as-primary-warehouse.md))
+- **[MotherDuck](https://motherduck.com/)** — cloud DuckDB for the portfolio deploy (see [ADR-0006](docs/adr/0006-motherduck-as-cloud-path.md))
+- **[Dagster](https://dagster.io/)** — sole orchestrator; assets, schedules, sensors, asset checks (see [ADR-0005](docs/adr/0005-dagster-as-sole-orchestrator.md))
+- **[Soda Core](https://www.soda.io/soda-core)** — contract-based quality, run as asset checks
+- **[MkDocs-Material](https://squidfunk.github.io/mkdocs-material/)** — auto-generated data dictionary site
 
-## Quick Start
+## Architectural decisions
+
+Six backfilled ADRs (Nygard format) cover the choices that load-bear on
+the rest of the design. Each one is under 200 lines.
+
+- [ADR-0001](docs/adr/0001-duckdb-as-primary-warehouse.md) — DuckDB as the primary warehouse
+- [ADR-0002](docs/adr/0002-sqlmesh-over-dbt.md) — SQLMesh over dbt
+- [ADR-0003](docs/adr/0003-single-sqlmesh-project.md) — Single SQLMesh project across all sources
+- [ADR-0004](docs/adr/0004-per-source-raw-catalogs.md) — Per-source raw DuckDB catalogs
+- [ADR-0005](docs/adr/0005-dagster-as-sole-orchestrator.md) — Dagster as the sole orchestrator
+- [ADR-0006](docs/adr/0006-motherduck-as-cloud-path.md) — MotherDuck as the cloud path
+
+## Quickstart
 
 ```bash
-# Setup
-task setup
+# Install (requires uv)
 task install
 
-# Configure API keys
-cp .env.example .env
-# Edit .env — set EBIRD_API_TOKEN, NOAA_API_TOKEN
+# Configure API keys — EBIRD_API_TOKEN and NOAA_API_TOKEN are free
+cp .env.example .env && $EDITOR .env
 
-# Launch Dagster UI (http://localhost:3000)
-task dagster:dev
-
-# Or materialize everything headless (pipelines + transforms + quality checks)
+# Run everything headlessly (ingest → transform → quality)
 task full-refresh
 
-# Smoke test (limited ingest + last 3 days of transforms)
-task verify
+# Or interactive: Dagster UI at localhost:3000
+task dagster:dev
+
+# Launch the Streamlit data explorer
+task streamlit
 ```
+
+Dagster is the one entrypoint — individual pipeline runs, quality checks,
+schedules, and sensors all happen as assets in the same DAG. See
+[ADR-0005](docs/adr/0005-dagster-as-sole-orchestrator.md).
 
 ## Backends
 
-Switch between local and cloud via `.env`:
+Flip between local and cloud via environment variables; the SQL never
+changes.
 
 ```bash
-# Local (default) — file-based DuckDB, zero-infra
+# Local (default) — file-based DuckDB, zero infra
 DATABOX_BACKEND=local
 DATABOX_GATEWAY=local
 
-# MotherDuck cloud
+# MotherDuck cloud — same SQL, md:* URIs
 DATABOX_BACKEND=motherduck
 DATABOX_GATEWAY=motherduck
 MOTHERDUCK_TOKEN=<your_token>
 ```
 
-`settings.database_path` and `settings.raw_*_path` are computed — they return `md:*` URIs for MotherDuck or local file paths otherwise.
+`settings.database_path` and `settings.raw_*_path` are computed — they
+resolve to local file paths or `md:` URIs depending on the backend. See
+[ADR-0001](docs/adr/0001-duckdb-as-primary-warehouse.md),
+[ADR-0004](docs/adr/0004-per-source-raw-catalogs.md),
+[ADR-0006](docs/adr/0006-motherduck-as-cloud-path.md).
 
-## Common Tasks
-
-| Task | Description |
-|------|-------------|
-| `task dagster:dev` | Start Dagster UI (asset graph, run logs, schedules) |
-| `task dagster:materialize` | Materialize every asset (full pipeline + transforms + quality) |
-| `task full-refresh` | Alias for `dagster:materialize` |
-| `task verify` | Smoke test: limited ingest + last 3 days of transforms |
-| `task transform:plan` | `sqlmesh plan --auto-apply` in `transforms/main` |
-| `task transform:run` | `sqlmesh run` |
-| `task transform:test` | `sqlmesh test` |
-| `task transform:ui` | SQLMesh UI |
-| `task streamlit` | Launch Streamlit data explorer |
-| `task db:reset` | Delete local DuckDB files |
-
-Everything else (individual pipeline runs, quality checks, scheduling) happens through Dagster assets — one entrypoint, visible lineage, automatic retries.
-
-## Project Structure
+## Repository layout
 
 ```
-databox/
-├── packages/                        # uv workspace monorepo
-│   ├── databox-config/              # Pydantic settings + YAML config loader
-│   ├── databox-sources/             # dlt ingestion + per-source configs
-│   │   └── databox_sources/
-│   │       ├── base.py              # PipelineSource protocol
-│   │       ├── registry.py          # Auto-discovers sources from config.yaml
-│   │       ├── ebird/               # eBird API
-│   │       ├── noaa/                # NOAA CDO API
-│   │       └── usgs/                # USGS NWIS Water Services
-│   ├── databox-orchestration/       # Dagster asset definitions
-│   └── databox-quality/             # Soda contract runner
-├── transforms/
-│   └── main/                        # Unified SQLMesh project (duckdb dialect)
-│       ├── config.yaml              # local + motherduck gateways
-│       └── models/
-│           ├── ebird/               # staging → intermediate → marts
-│           ├── noaa/                # staging → marts
-│           ├── usgs/                # staging → marts
-│           └── analytics/           # cross-domain (bird + weather + streams)
-├── soda/
-│   ├── datasources/                 # DuckDB/MotherDuck connection config
-│   └── contracts/                   # Data quality contracts per schema layer
-├── app/                             # Streamlit data explorer
-├── data/                            # DuckDB files (gitignored)
-│   ├── databox.duckdb               # Transformed marts catalog
-│   ├── raw_ebird.duckdb             # dlt landing zone (parallelized per source)
-│   ├── raw_noaa.duckdb
-│   └── raw_usgs.duckdb
-└── scripts/                         # Utility scripts
+packages/                  # uv workspace
+├── databox-config/        # Pydantic settings, YAML loader
+├── databox-sources/       # dlt ingestion + per-source configs
+├── databox-orchestration/ # Dagster assets + semantic metrics helper
+└── databox-quality/       # Soda contract runner
+
+transforms/main/           # Unified SQLMesh project (ADR-0003)
+├── config.yaml            # local + motherduck gateways
+├── metrics/               # semantic metrics registry
+└── models/
+    ├── ebird/  noaa/  usgs/   # staging → intermediate → marts
+    └── analytics/             # cross-domain marts
+
+soda/contracts/            # One Soda contract per SQLMesh model
+
+docs/
+├── adr/                   # 6 backfilled ADRs
+├── dictionary/            # Auto-generated by scripts/generate_docs.py
+└── {metrics,contracts,...}.md
+
+scripts/
+├── generate_docs.py       # Data-dictionary generator
+└── schema_gate.py         # CI breaking-change gate
+
+data/                      # DuckDB files (gitignored)
 ```
 
-### Schema Layering
+## Published artifacts
 
-```
-raw_ebird / raw_noaa / raw_usgs        ← dlt loads (untouched API data)
-ebird_staging / noaa_staging / usgs_staging  ← SQLMesh stg_* views (renames only)
-ebird / noaa / usgs                    ← SQLMesh marts (fct_* / dim_*)
-analytics                              ← cross-domain marts
-```
-
-Raw catalogs are split per-source DuckDB files so dlt can load in parallel.
-
-## Data Sources
-
-### eBird
-- **API**: eBird API v2 (free, requires token)
-- **Resources**: recent_observations, notable_observations, species_list, hotspots, taxonomy, region_stats
-- **Transforms**: `raw_ebird` → `ebird_staging` → intermediate → `ebird.*` marts + `analytics` cross-domain
-
-### NOAA CDO
-- **API**: NOAA Climate Data Online v2 (free, requires token)
-- **Resources**: daily_weather (TMAX/TMIN/PRCP/SNOW/AWND), stations, datasets
-- **Transforms**: `raw_noaa` → `noaa_staging` → `noaa.fct_daily_weather`
-
-### USGS Water Services
-- **API**: NWIS Daily Values (no API key required)
-- **Resources**: daily_values (discharge/gage height/water temp), sites
-- **Transforms**: `raw_usgs` → `usgs_staging` → `usgs.fct_daily_streamflow`
-
-## Adding a New Data Source
-
-1. Create `packages/databox-sources/databox_sources/<source>/`
-   - `source.py` — dlt source with `@dlt.source`/`@dlt.resource`, implements `PipelineSource`, exposes `create_pipeline(config)` factory
-   - `config.yaml` — source module, schedule, params, quality rules
-
-2. Add transform models at `transforms/main/models/<source>/`
-   - Read from `raw_<source>.*` (auto-created by dlt)
-   - Staging → `<source>_staging.*`, marts → `<source>.*`
-
-3. Add Soda contracts at `soda/contracts/<source>_staging/` and `soda/contracts/<source>/`
-
-4. Add secret to `.env`: `<SOURCE>_API_TOKEN=your_key_here`
-
-No orchestration wiring needed — Dagster auto-discovers from the source registry.
+- **Data dictionary + lineage:** https://doctacon.github.io/databox/ — regenerates on every push to `main`
+- **[docs/metrics.md](docs/metrics.md)** — semantic metrics registry and `resolve_metric_query` helper
+- **[docs/analytics-examples.md](docs/analytics-examples.md)** — representative queries against the flagship mart
+- **[docs/contracts.md](docs/contracts.md)** — Soda contract conventions + schema-contract gate escape hatch
+- **[docs/incremental-loading.md](docs/incremental-loading.md)** — per-resource write disposition, keys, backfill
 
 ## Development
 
 ```bash
-task install        # Install dependencies
-task verify         # Smoke test via Dagster
-task lint           # Ruff lint
-task format         # Ruff format
-task typecheck      # mypy
-task test           # pytest
+task install         # Install dependencies (uv sync)
+task verify          # Smoke test via Dagster
+task lint            # Ruff lint
+task format          # Ruff format
+task typecheck       # mypy
+task test            # pytest
 ```
-
-See [docs/contracts.md](docs/contracts.md) for the schema-contract gate and the
-`accept-breaking-change` escape hatch used on PRs that intentionally break
-downstream consumers.
-
-See [docs/incremental-loading.md](docs/incremental-loading.md) for the
-per-resource write disposition, primary keys, idempotency guarantee, and
-backfill commands.
-
-See [docs/analytics-examples.md](docs/analytics-examples.md) for example
-queries against the flagship cross-domain mart
-(`analytics.fct_species_environment_daily`) that joins eBird observations
-with NOAA weather and USGS streamflow at species × H3 cell × day grain.
-
-See [docs/metrics.md](docs/metrics.md) for the semantic metrics layer —
-seven metrics (species richness, observation intensity, heat-stress index,
-rainfall/discharge anomaly z-scores, raw observation/checklist counts)
-defined once in SQLMesh and queryable by name via
-`databox_orchestration.metrics.resolve_metric_query`.
-
-## Data dictionary
-
-Auto-generated data dictionary + lineage site published via GitHub Pages:
-**https://doctacon.github.io/databox/**
-
-Every SQLMesh model has a page listing its columns, types, Soda-contract
-checks, and direct upstream/downstream dependencies. A global Mermaid
-lineage graph links every node back to its page. Regenerate locally with:
-
-```bash
-uv run python scripts/generate_docs.py
-uv run mkdocs serve   # live preview at localhost:8000
-```
-
-The `.github/workflows/docs.yaml` workflow rebuilds and deploys on every
-push to `main`.
 
 ## License
 
-MIT
+MIT — see [LICENSE](LICENSE).

--- a/docs/adr/0001-duckdb-as-primary-warehouse.md
+++ b/docs/adr/0001-duckdb-as-primary-warehouse.md
@@ -1,0 +1,51 @@
+# ADR-0001: DuckDB as the primary warehouse
+
+**Status:** Accepted · 2026-02 · reaffirmed 2026-04 when MotherDuck cloud
+path was added (see ADR-0006).
+
+## Context
+
+Databox is a single-operator data platform. Three hard constraints shape
+every infrastructure choice:
+
+1. **Zero fixed cost.** No always-on database instance, no managed
+   warehouse contract, no per-seat BI licensing.
+2. **Zero-infra local mode.** A new contributor (or a future me on a new
+   laptop) should be productive in minutes, not after provisioning
+   anything.
+3. **Analytical workload profile.** The data is batch-ingested daily,
+   modeled with SQL, and queried by a handful of dashboards. No OLTP, no
+   high concurrency, no real-time writes.
+
+Candidate stacks considered: Postgres + dbt, Snowflake (free tier),
+BigQuery (free tier), ClickHouse, DuckDB, Parquet-on-S3 + Athena.
+
+## Decision
+
+Use DuckDB as the primary warehouse. All transformations run against
+DuckDB; all marts live in DuckDB files under `data/`.
+
+## Consequences
+
+**Positive:**
+- Zero infra. The database is a `.duckdb` file on disk.
+- Analytical queries against the flagship mart finish in tens of
+  milliseconds locally. No tuning, no clustering keys.
+- Columnar storage + vectorized execution make this genuinely fast for
+  the workload, not just "fine for small data".
+- First-class Parquet, JSON, and HTTP extensions mean dlt and downstream
+  consumers can read/write a wide variety of formats without glue code.
+- Open source (MIT). No vendor lock-in.
+
+**Negative:**
+- No concurrent writes. Not an issue at single-operator scale; would be a
+  real problem at team scale.
+- No row-level security, no fine-grained access control. Out of scope
+  for this project; would be disqualifying at enterprise scale.
+- The `.duckdb` file is binary and doesn't diff cleanly — source of
+  truth is always the raw ingest + transform code, never the database
+  file itself.
+
+**Neutral:**
+- The cloud path is handled by MotherDuck (see ADR-0006), which accepts
+  the same DuckDB SQL. That keeps the local/cloud gap thin.

--- a/docs/adr/0002-sqlmesh-over-dbt.md
+++ b/docs/adr/0002-sqlmesh-over-dbt.md
@@ -1,0 +1,56 @@
+# ADR-0002: SQLMesh over dbt
+
+**Status:** Accepted · 2026-02
+
+## Context
+
+The transformation layer needs to handle:
+
+- dependency-aware DAG execution
+- environment/virtual data mart separation (dev, staging, prod without
+  copying data)
+- model-level tests and audits
+- incremental models for time-partitioned data (daily bird observations,
+  daily weather)
+- change detection (plan before apply)
+- DuckDB dialect support
+
+Two mature Python-native options exist: **dbt-core** and **SQLMesh**.
+Both are open source. Both work with DuckDB.
+
+## Decision
+
+Use SQLMesh for all SQL transformations under `transforms/main/`.
+
+## Consequences
+
+**Positive:**
+- **Virtual data environments out of the box.** SQLMesh's `plan` model
+  creates cost-free virtual views per environment. Promoting to prod is
+  a view-swap, not a materialized copy. dbt's equivalent (`defer`) is
+  limited and much more manual.
+- **Column-level change detection.** SQLMesh categorizes changes as
+  breaking vs non-breaking automatically. A column rename shows up
+  differently than a pure-SQL refactor. dbt sees only "the model
+  changed".
+- **Native semantic metrics.** SQLMesh's `METRIC` DDL lets the semantic
+  layer live next to the models. The metrics layer in this repo
+  (`transforms/main/metrics/`) exists because SQLMesh supports it
+  natively. dbt's Semantic Layer requires dbt Cloud.
+- **Python models work cleanly** without the dbt-python compatibility
+  caveats.
+- **Same mental model for local and MotherDuck** via gateways
+  (see ADR-0006).
+
+**Negative:**
+- Smaller community than dbt. When looking up "how do I X in SQLMesh",
+  answers are often thinner.
+- Fewer packaged providers than dbt's hub.
+- Staff-level engineers are statistically far more likely to have dbt
+  experience than SQLMesh. This repo has to teach SQLMesh in the README,
+  which adds one more concept to absorb.
+
+**Neutral:**
+- SQLMesh audits replace dbt's tests, but Soda contracts (see
+  `soda/contracts/`) cover the cross-cutting quality checks separately,
+  so the choice of SQLMesh vs dbt test syntax does not load-bear.

--- a/docs/adr/0003-single-sqlmesh-project.md
+++ b/docs/adr/0003-single-sqlmesh-project.md
@@ -1,0 +1,56 @@
+# ADR-0003: Single SQLMesh project across all sources
+
+**Status:** Accepted · 2026-02
+
+## Context
+
+The platform ingests from three sources (eBird, NOAA, USGS) with distinct
+staging layers. An earlier iteration used one SQLMesh project per source
+under `transformations/ebird/`, `transformations/noaa/`, `transformations/usgs/`,
+each with its own `config.yaml` and its own state.
+
+This worked until the first cross-domain mart. Joining observations across
+multiple source-scoped projects requires either:
+
+1. materializing each source into a shared catalog and running a fourth
+   "home-team" project on top, or
+2. treating each cross-domain query as a single-use script outside the
+   transformation framework, or
+3. collapsing everything into one project.
+
+Option 1 duplicates state. SQLMesh maintains its own snapshot/state table
+per project; keeping four projects in sync mid-refresh was fragile. Option
+2 surrenders every benefit of SQLMesh (tests, lineage, environments) for
+cross-domain models, which are exactly where the interesting analytics
+live.
+
+## Decision
+
+Collapse all source-specific projects into a **single SQLMesh project**
+at `transforms/main/`. Models are namespaced by source schema
+(`ebird.*`, `ebird_staging.*`, `noaa.*`, `usgs.*`, `analytics.*`) but share
+one project, one state, one `sqlmesh plan`.
+
+## Consequences
+
+**Positive:**
+- One DAG. Cross-domain marts (`analytics.fct_species_environment_daily`)
+  are first-class, not a bolt-on.
+- One `sqlmesh plan` shows every downstream impact of a change,
+  regardless of source boundary.
+- One environment promotion gates the entire graph consistently.
+- The Dagster asset graph maps 1:1 to SQLMesh models — simpler
+  orchestration wiring.
+
+**Negative:**
+- A single-source change forces re-planning against the whole project.
+  Plans stay fast (~seconds) at current scale but this would start to
+  hurt past low-hundreds of models.
+- No hard wall between source teams. At a real organization with
+  independent owners per source, separate projects (with explicit
+  contracts between them) might be worth the state-management cost.
+
+**Neutral:**
+- Folder structure under `transforms/main/models/` still organizes by
+  source for humans — the single-project decision is about SQLMesh state,
+  not repo layout.

--- a/docs/adr/0004-per-source-raw-catalogs.md
+++ b/docs/adr/0004-per-source-raw-catalogs.md
@@ -1,0 +1,54 @@
+# ADR-0004: Per-source raw DuckDB catalogs
+
+**Status:** Accepted · 2026-03
+
+## Context
+
+dlt writes ingested records into a landing zone. Early versions used a
+single catalog (`data/databox.duckdb`) with per-source schemas
+(`raw_ebird.*`, `raw_noaa.*`, `raw_usgs.*`). This worked for correctness
+but serialized all loads:
+
+- DuckDB holds a file-level lock for writes. Concurrent pipelines
+  blocked each other.
+- A failed load partially touched the same file that downstream
+  transforms were about to read.
+- The transform-side DuckDB file grew large, and checkpoint/rollback
+  semantics interacted awkwardly with dlt's own staging commit.
+
+## Decision
+
+Split raw storage into **per-source DuckDB files**:
+
+```
+data/raw_ebird.duckdb
+data/raw_noaa.duckdb
+data/raw_usgs.duckdb
+data/databox.duckdb   # transform output catalog only
+```
+
+`settings.raw_<source>_path` returns the source-specific path for both
+local and MotherDuck backends. SQLMesh staging models `ATTACH` each raw
+file read-only as needed.
+
+## Consequences
+
+**Positive:**
+- dlt pipelines run in parallel without lock contention. The full
+  refresh time drops substantially when multiple sources ingest together.
+- A bad ingest for one source cannot corrupt another source's raw data.
+- Each source's raw file can be deleted/rebuilt independently during
+  debugging.
+- The transform catalog stays small — it holds only modeled data.
+
+**Negative:**
+- Multiple files to back up / sync to MotherDuck instead of one.
+- SQL that crosses raw sources must `ATTACH` all relevant files, which
+  is slightly more verbose than referencing shared schemas.
+- `list_databases` / `list_tables` tooling needs to know where to look,
+  not just open one file.
+
+**Neutral:**
+- On MotherDuck, "files" become "databases" in the same account, so the
+  per-source split carries over naturally without the filesystem-level
+  lock concern (MotherDuck handles that internally).

--- a/docs/adr/0005-dagster-as-sole-orchestrator.md
+++ b/docs/adr/0005-dagster-as-sole-orchestrator.md
@@ -1,0 +1,53 @@
+# ADR-0005: Dagster as the sole orchestrator
+
+**Status:** Accepted · 2026-03
+
+## Context
+
+An earlier version of this repo shipped two overlapping entrypoints: a
+Typer-based `databox` CLI (`packages/databox-cli/`) and a Dagster asset
+graph. The CLI exposed `databox run ebird`, `databox transform run`,
+`databox quality report`, etc. Dagster exposed the same operations as
+materializable assets.
+
+That duplication was confusing. New contributors asked "which one do I
+use?" and the answer was "it depends". Worse, the CLI did not have asset
+lineage, retries, sensors, or scheduling — so non-trivial workflows
+bypassed it anyway. The CLI was carrying maintenance cost without
+buying much.
+
+## Decision
+
+Retire the Typer CLI. **Dagster is the single entrypoint** for every
+non-trivial operation: ingestion, transformation, quality checks,
+schedules, sensors, backfills. A thin `Taskfile.yml` wraps the common
+Dagster commands (`task dagster:dev`, `task dagster:materialize`,
+`task full-refresh`) for ergonomic reasons but does not implement any
+logic of its own.
+
+## Consequences
+
+**Positive:**
+- One mental model. New contributors learn Dagster assets and see
+  every pipeline step as a node in one graph.
+- Native lineage across dlt → SQLMesh → Soda. The UI shows that
+  `analytics.fct_species_environment_daily` depends on
+  `noaa.int_weather_by_h3_day` which depends on `raw_noaa.daily_weather`,
+  end to end, without extra wiring.
+- Soda contracts run as Dagster **asset checks**, gating downstream
+  materialization on quality automatically.
+- Schedules, sensors, and partition backfills are first-class. No
+  cron-on-top-of-CLI duct tape.
+
+**Negative:**
+- Dagster is a heavier dependency than Typer. It pulls in a web UI,
+  gRPC, and a state store. Acceptable for this scale — not a concern
+  at ~dozens of assets.
+- Invoking a single asset from a terminal is slightly more ceremony
+  than `databox run ebird` was. `task dagster:materialize -- asset_key`
+  paves over this.
+
+**Neutral:**
+- The `task` wrapper is intentionally thin. It could be replaced with a
+  Makefile or raw `dagster asset materialize` invocations without
+  changing the architecture.

--- a/docs/adr/0006-motherduck-as-cloud-path.md
+++ b/docs/adr/0006-motherduck-as-cloud-path.md
@@ -1,0 +1,67 @@
+# ADR-0006: MotherDuck as the cloud path
+
+**Status:** Accepted · 2026-04
+
+## Context
+
+The local stack (ADR-0001) is good enough for daily operation but
+breaks down for two use cases: sharing the data with another laptop,
+and handing a recruiter a live dashboard they can click without cloning
+the repo.
+
+The candidate cloud paths considered:
+
+1. **Managed Postgres / Snowflake / BigQuery** — wrong workload fit
+   (OLTP / expensive / egress costs), requires rewriting models off
+   DuckDB dialect.
+2. **Parquet-on-S3 + Athena** — works but forces the dashboard layer
+   to speak a different dialect than the local stack, doubling the
+   test surface.
+3. **MotherDuck** — cloud DuckDB. Accepts `md:` URIs as drop-in
+   replacements for local paths. Same SQL dialect, same extensions,
+   same features as local DuckDB.
+4. **Self-hosted DuckDB on a VM** — defeats the "no always-on infra"
+   constraint (ADR-0001).
+
+## Decision
+
+Use **MotherDuck** as the cloud path. Keep the local path as default.
+
+Architecture is gateway-based: `DATABOX_BACKEND=local` or `=motherduck`
+switches `settings.database_path` and `settings.raw_*_path` between
+file paths and `md:` URIs. SQLMesh gateways (`local`, `motherduck`)
+mirror the same split. No SQL changes between modes.
+
+## Consequences
+
+**Positive:**
+- Identical SQL. The same transforms and the same Soda contracts run
+  locally and in MotherDuck. No dialect split.
+- Free hobbyist tier covers the portfolio use case without any upfront
+  cost.
+- Shared dashboards resolve `md:` URIs directly — no ETL-to-dashboard
+  copy step.
+- Backup is a `COPY FROM LOCAL TO md:` on demand. Switching backends is
+  an environment-variable flip, reversible.
+
+**Negative:**
+- MotherDuck is proprietary SaaS. The *data* and *SQL* are portable;
+  the *service* is not. If MotherDuck's pricing or service changes,
+  the fallback is "stay on local DuckDB and publish static Parquet
+  snapshots".
+- Some DuckDB extensions load in a different order on MotherDuck than
+  locally (the H3 community extension was the first example). The
+  metrics layer hit this during implementation (see the semantic-metrics
+  research record) — working-around requires invoking extension loading
+  explicitly.
+- Network round-trips are now a thing. Local DuckDB queries returned in
+  milliseconds; MotherDuck queries are typically 10–100× slower for the
+  same shape due to network, though still comfortably under a second
+  for the dashboards in this repo.
+
+**Neutral:**
+- This violates the project's default preference for open-source over
+  proprietary (noted in the root CLAUDE.md). The trade-off is
+  explicit: proprietary service acceptable **only because** the data
+  and SQL layer above it are fully portable — the same stack keeps
+  running on local DuckDB if MotherDuck goes away.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,18 @@
+# Architecture Decision Records
+
+Backfilled ADRs for the load-bearing architectural choices in this repo.
+Each ADR follows [Michael Nygard's
+format](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions):
+**Context**, **Decision**, **Consequences**, **Status**.
+
+Numbered in order of decision, not importance. A decision that turned out
+to be wrong would be marked **Superseded** and keep its number.
+
+| ID | Title | Status |
+|---|---|---|
+| [ADR-0001](0001-duckdb-as-primary-warehouse.md) | DuckDB as the primary warehouse | Accepted |
+| [ADR-0002](0002-sqlmesh-over-dbt.md) | SQLMesh over dbt | Accepted |
+| [ADR-0003](0003-single-sqlmesh-project.md) | Single SQLMesh project across all sources | Accepted |
+| [ADR-0004](0004-per-source-raw-catalogs.md) | Per-source raw DuckDB catalogs | Accepted |
+| [ADR-0005](0005-dagster-as-sole-orchestrator.md) | Dagster as the sole orchestrator | Accepted |
+| [ADR-0006](0006-motherduck-as-cloud-path.md) | MotherDuck as the cloud path | Accepted |

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,11 +19,19 @@ contracts, and orchestrates with Dagster on DuckDB / MotherDuck.
 - **[Incremental loading](incremental-loading.md)** — dlt incremental and
   SQLMesh incremental-by-time notes.
 
-## Case study
+## Architecture decisions
 
-The case-study README (architecture walkthrough and decision record index) is
-tracked in `ticket:architecture-docs` and will be linked from here once
-published.
+Six backfilled ADRs (Nygard format) explain the load-bearing choices:
+
+- [ADR-0001 — DuckDB as the primary warehouse](adr/0001-duckdb-as-primary-warehouse.md)
+- [ADR-0002 — SQLMesh over dbt](adr/0002-sqlmesh-over-dbt.md)
+- [ADR-0003 — Single SQLMesh project across all sources](adr/0003-single-sqlmesh-project.md)
+- [ADR-0004 — Per-source raw DuckDB catalogs](adr/0004-per-source-raw-catalogs.md)
+- [ADR-0005 — Dagster as the sole orchestrator](adr/0005-dagster-as-sole-orchestrator.md)
+- [ADR-0006 — MotherDuck as the cloud path](adr/0006-motherduck-as-cloud-path.md)
+
+The root README frames the platform as a case study with system and
+data-flow diagrams in Mermaid.
 
 ## Regenerate
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,3 +62,11 @@ nav:
   - Metrics: metrics.md
   - Contracts: contracts.md
   - Incremental loading: incremental-loading.md
+  - Architecture decisions:
+      - Overview: adr/README.md
+      - ADR-0001 DuckDB warehouse: adr/0001-duckdb-as-primary-warehouse.md
+      - ADR-0002 SQLMesh over dbt: adr/0002-sqlmesh-over-dbt.md
+      - ADR-0003 Single SQLMesh project: adr/0003-single-sqlmesh-project.md
+      - ADR-0004 Per-source raw catalogs: adr/0004-per-source-raw-catalogs.md
+      - ADR-0005 Dagster sole orchestrator: adr/0005-dagster-as-sole-orchestrator.md
+      - ADR-0006 MotherDuck cloud path: adr/0006-motherduck-as-cloud-path.md


### PR DESCRIPTION
## Summary

- Rewrites the root README as a case study: leads with Mermaid C4 system diagram + data-flow diagram, then a \"what this demonstrates\" table mapping staff-level capability claims to tickets + evidence.
- Adds `docs/adr/` with six Nygard-format ADRs: DuckDB warehouse, SQLMesh over dbt, single SQLMesh project, per-source raw catalogs, Dagster sole orchestrator, MotherDuck cloud path. Each under 200 lines.
- MkDocs nav carries the ADR section; strict build stays clean.
- Adds MIT LICENSE file referenced from the README badge.

Closes ticket:architecture-docs (phase 4 of initiative:staff-portfolio-readiness).

## Test plan

- [x] \`uv run mkdocs build --strict\` — clean.
- [x] \`uv run ruff check .\` + \`uv run ruff format --check .\` — clean.
- [x] \`uv run pytest\` — 30 passed.
- [x] README is 244 lines (under 300 budget).
- [ ] Mermaid diagrams render on GitHub (will verify via the rendered PR view once CI pushes a preview).
- [ ] Screenshots under docs/images/ deferred — Dagster/Dive UIs require a live instance. Captured as residual follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)