### PR TITLE
refactor(taskfile): trim to 96 lines, move raw CLIs to docs/commands.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,15 +65,16 @@ databox status                            # Show pipeline status & freshness
 
 ### Task
 ```bash
-task setup                    # Setup environment
-task install                  # Install dependencies
-task pipeline:list            # List pipelines
-task pipeline:run -- ebird    # Run a pipeline
-task transform:plan           # SQLMesh plan
-task transform:run            # SQLMesh run
-task full-refresh             # Run everything
+task setup                    # Create .venv + bootstrap .env
+task install                  # uv sync + pre-commit hook install
+task full-refresh             # Dagster: all dlt + SQLMesh + Soda
+task verify                   # Smoke full-refresh (DATABOX_SMOKE=1)
+task ci                       # Ruff + mypy + pytest + secret scan
+task dagster:dev              # Launch Dagster UI
 task streamlit                # Launch data explorer
 ```
+
+Raw SQLMesh / Dagster / pytest invocations: [docs/commands.md](docs/commands.md).
 
 ## Data Sources
 

--- a/README.md
+++ b/README.md
@@ -229,13 +229,14 @@ data/                      # DuckDB files (gitignored)
 ## Development
 
 ```bash
-task install         # Install dependencies (uv sync)
-task verify          # Smoke test via Dagster
-task lint            # Ruff lint
-task format          # Ruff format
-task typecheck       # mypy
-task test            # pytest
+task install         # Install dependencies (uv sync + pre-commit hook)
+task verify          # Smoke full-refresh via Dagster (DATABOX_SMOKE=1)
+task ci              # Ruff + mypy + pytest + secret scan
 ```
+
+Raw lint / format / test / SQLMesh / Dagster CLIs are in
+[docs/commands.md](docs/commands.md). `Taskfile.yaml` deliberately
+keeps only targets that compose multiple commands or inject env vars.
 
 ## License
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -1,19 +1,14 @@
 version: '3'
 
-vars:
-  PROJECT_NAME: databox
-  PYTHON_VERSION: "3.12"
-  VENV_DIR: .venv
-  DATA_DIR: ./data
+# Targets compose / inject env / encode defaults. Raw CLI wrappers → docs/commands.md.
 
-env:
-  PYTHONPATH: .
-
+vars: { VENV_DIR: .venv, DATA_DIR: ./data }
+env: { PYTHONPATH: . }
 output: prefixed
 
 tasks:
   setup:
-    desc: "Create virtual environment (skipped if .venv already exists)"
+    desc: "Create .venv + bootstrap .env from .env.example"
     cmds:
       - uv venv {{.VENV_DIR}}
       - test -f .env || cp .env.example .env
@@ -21,7 +16,7 @@ tasks:
       - test -d {{.VENV_DIR}}
 
   install:
-    desc: "Install project dependencies"
+    desc: "Install deps + pre-commit hook (setup + uv sync + hook install)"
     deps: [setup]
     cmds:
       - uv sync
@@ -31,149 +26,18 @@ tasks:
       - uv.lock
       - scripts/setup_pre_commit.sh
 
-  lint:
-    desc: "Run code linting"
-    deps: [install]
-    cmds:
-      - "{{.VENV_DIR}}/bin/ruff check . --fix --unsafe-fixes"
-
-  format:
-    desc: "Format code"
-    deps: [install]
-    cmds:
-      - "{{.VENV_DIR}}/bin/ruff format ."
-      - "{{.VENV_DIR}}/bin/ruff check . --fix"
-
-  typecheck:
-    desc: "Run type checking"
-    deps: [install]
-    cmds:
-      - "{{.VENV_DIR}}/bin/mypy . --ignore-missing-imports"
-
-  test:
-    desc: "Run all tests"
-    deps: [install]
-    cmds:
-      - "{{.VENV_DIR}}/bin/pytest"
-
-  test:unit:
-    desc: "Run unit tests only"
-    deps: [install]
-    cmds:
-      - "{{.VENV_DIR}}/bin/pytest -m unit"
-
-  test:integration:
-    desc: "Run integration tests"
-    deps: [install]
-    cmds:
-      - "{{.VENV_DIR}}/bin/pytest -m integration"
-
-  test:e2e:
-    desc: "Run end-to-end tests"
-    deps: [install]
-    cmds:
-      - "{{.VENV_DIR}}/bin/pytest -m e2e"
-
-  test:coverage:
-    desc: "Run tests with coverage"
-    deps: [install]
-    cmds:
-      - "{{.VENV_DIR}}/bin/pytest --cov=. --cov-report=html"
-
-  check-secrets:
-    desc: "Check for secrets in code"
-    cmds:
-      - python scripts/check_secrets.py {{.CLI_ARGS | default "."}}
-
-  pre-commit:
-    desc: "Run pre-commit hooks"
-    deps: [install]
-    cmds:
-      - "{{.VENV_DIR}}/bin/pre-commit run --all-files"
-
-  # Transform commands (sqlmesh directly — useful for dev/debugging)
-  transform:plan:
-    desc: "Plan SQLMesh transformations"
-    deps: [install]
-    dir: transforms/main
-    cmds:
-      - "../../{{.VENV_DIR}}/bin/sqlmesh plan --auto-apply {{.CLI_ARGS}}"
-
-  transform:run:
-    desc: "Run SQLMesh transformations"
-    deps: [install]
-    dir: transforms/main
-    cmds:
-      - "../../{{.VENV_DIR}}/bin/sqlmesh run {{.CLI_ARGS}}"
-
-  transform:test:
-    desc: "Run SQLMesh tests"
-    deps: [install]
-    dir: transforms/main
-    cmds:
-      - "../../{{.VENV_DIR}}/bin/sqlmesh test {{.CLI_ARGS}}"
-
-  transform:ui:
-    desc: "Start SQLMesh UI"
-    deps: [install]
-    dir: transforms/main
-    cmds:
-      - "../../{{.VENV_DIR}}/bin/sqlmesh ui"
-
-  # CI/CD
   ci:
-    desc: "Run all CI checks"
-    cmds:
-      - task: lint
-      - task: typecheck
-      - task: test
-      - task: check-secrets
-
-  # Clean
-  clean:
-    desc: "Clean build artifacts"
-    cmds:
-      - rm -rf build/
-      - rm -rf dist/
-      - rm -rf *.egg-info/
-      - rm -rf .pytest_cache/
-      - rm -rf .coverage
-      - rm -rf htmlcov/
-      - find . -type d -name __pycache__ -exec rm -rf {} +
-      - find . -type f -name "*.pyc" -delete
-
-  clean-all:
-    desc: "Clean everything including venv and data"
-    deps: [clean]
-    cmds:
-      - rm -rf {{.VENV_DIR}}
-      - rm -rf {{.DATA_DIR}}
-      - rm -rf .dlt_state/
-
-  db:reset:
-    desc: "Reset the database (local files only — MotherDuck databases must be dropped manually)"
-    cmds:
-      - rm -f data/databox.duckdb data/raw_ebird.duckdb data/raw_noaa.duckdb data/raw_usgs.duckdb
-      - echo "Database reset complete (local files only — MotherDuck databases must be dropped manually)"
-
-  # Full refresh
-  full-refresh:
-    desc: "Full data refresh — all pipelines + transforms + quality checks via Dagster"
-    cmds:
-      - task: dagster:materialize
-
-  # Dagster
-  dagster:dev:
-    desc: "Start Dagster development server"
+    desc: "Compose every CI gate: ruff + mypy + pytest + secret scan"
     deps: [install]
-    env:
-      DAGSTER_HOME: "{{.USER_WORKING_DIR}}/.dagster"
-      PYTHONPATH: "{{.USER_WORKING_DIR}}"
     cmds:
-      - "{{.VENV_DIR}}/bin/dagster dev -f packages/databox/databox/orchestration/definitions.py"
+      - "{{.VENV_DIR}}/bin/ruff check ."
+      - "{{.VENV_DIR}}/bin/ruff format --check ."
+      - "{{.VENV_DIR}}/bin/mypy . --ignore-missing-imports"
+      - "{{.VENV_DIR}}/bin/pytest"
+      - python scripts/check_secrets.py .
 
-  dagster:materialize:
-    desc: "Materialize all Dagster assets (runs all pipelines + transforms + quality checks)"
+  full-refresh:
+    desc: "Run every dlt source + SQLMesh + every Soda check through Dagster"
     deps: [install]
     env:
       DAGSTER_HOME: "{{.USER_WORKING_DIR}}/.dagster"
@@ -182,7 +46,7 @@ tasks:
       - "{{.VENV_DIR}}/bin/dagster asset materialize --select '*' -f packages/databox/databox/orchestration/definitions.py"
 
   verify:
-    desc: "Smoke test via Dagster — limited ingest (5 items/resource) + last 3 days of transforms"
+    desc: "Smoke full-refresh — DATABOX_SMOKE=1 caps each source to 5 items"
     deps: [install]
     env:
       DAGSTER_HOME: "{{.USER_WORKING_DIR}}/.dagster"
@@ -191,32 +55,40 @@ tasks:
     cmds:
       - "{{.VENV_DIR}}/bin/dagster asset materialize --select '*' -f packages/databox/databox/orchestration/definitions.py"
 
-  # Streamlit
+  dagster:dev:
+    desc: "Launch Dagster UI with DAGSTER_HOME + PYTHONPATH + definitions path"
+    deps: [install]
+    env:
+      DAGSTER_HOME: "{{.USER_WORKING_DIR}}/.dagster"
+      PYTHONPATH: "{{.USER_WORKING_DIR}}"
+    cmds:
+      - "{{.VENV_DIR}}/bin/dagster dev -f packages/databox/databox/orchestration/definitions.py"
+
   streamlit:
-    desc: "Start Databox Explorer dashboard"
+    desc: "Launch Databox Explorer (cd app/ + streamlit run main.py)"
     deps: [install]
     dir: app
     cmds:
       - "../{{.VENV_DIR}}/bin/streamlit run main.py"
 
-  # Watch
-  watch:lint:
-    desc: "Watch files and run linting"
-    deps: [install]
-    watch: true
-    sources:
-      - "**/*.py"
+  db:reset:
+    desc: "Delete local DuckDB files (MotherDuck dbs must be dropped manually)"
     cmds:
-      - task: lint
+      - rm -f data/databox.duckdb data/raw_ebird.duckdb data/raw_noaa.duckdb data/raw_usgs.duckdb
+      - echo "Local DBs reset — MotherDuck dbs (if any) must be dropped manually"
 
-  watch:test:
-    desc: "Watch files and run tests"
-    deps: [install]
-    watch: true
-    sources:
-      - "**/*.py"
+  clean:
+    desc: "Remove build + test + cache artifacts"
     cmds:
-      - task: test
+      - rm -rf build/ dist/ *.egg-info/ .pytest_cache/ .coverage htmlcov/
+      - find . -type d -name __pycache__ -exec rm -rf {} +
+      - find . -type f -name "*.pyc" -delete
+
+  clean-all:
+    desc: "Clean + drop .venv + data/ + .dlt_state/"
+    deps: [clean]
+    cmds:
+      - rm -rf {{.VENV_DIR}} {{.DATA_DIR}} .dlt_state/
 
   default:
     desc: "Show available tasks"

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,81 @@
+# Commands Cheatsheet
+
+`Taskfile.yaml` only keeps targets that **compose multiple commands**,
+**inject environment variables**, or **encode a non-obvious default**.
+Everything else is a direct call into a third-party CLI — listed below
+so a forker can run the underlying command without learning a Task
+target that merely renamed it.
+
+All `uv run` commands assume you are at the repo root.
+
+## Linting + formatting
+
+```bash
+uv run ruff check .                  # lint
+uv run ruff check . --fix            # lint + auto-fix
+uv run ruff format .                 # format in place
+uv run ruff format --check .         # format check (no write)
+uv run mypy . --ignore-missing-imports
+```
+
+`task ci` composes all four gates plus pytest + secret scan.
+
+## Testing
+
+```bash
+uv run pytest                        # full suite
+uv run pytest -m unit                # unit tests only
+uv run pytest -m integration         # integration tests
+uv run pytest -m e2e                 # end-to-end tests
+uv run pytest --cov=. --cov-report=html
+```
+
+Test markers are defined in `pyproject.toml` under `[tool.pytest.ini_options]`.
+
+## SQLMesh
+
+Run from `transforms/main/` — SQLMesh picks up `config.py` there.
+
+```bash
+cd transforms/main
+uv run sqlmesh plan --auto-apply     # plan + apply changes
+uv run sqlmesh run                   # run scheduled models
+uv run sqlmesh test                  # run SQLMesh unit tests
+uv run sqlmesh ui                    # start SQLMesh UI
+uv run sqlmesh plan dev              # plan into dev env
+```
+
+## Dagster (beyond `dagster:dev` / `full-refresh` / `verify`)
+
+```bash
+export DAGSTER_HOME="$PWD/.dagster"
+export PYTHONPATH="$PWD"
+
+uv run dagster asset materialize --select <key> \
+  -f packages/databox/databox/orchestration/definitions.py
+
+uv run dagster asset wipe --all \
+  -f packages/databox/databox/orchestration/definitions.py
+```
+
+## Pre-commit
+
+```bash
+uv run pre-commit run --all-files    # run every hook across every file
+uv run pre-commit run ruff           # run one hook
+```
+
+## Secret scan
+
+```bash
+python scripts/check_secrets.py      # scan repo root
+python scripts/check_secrets.py path/to/file.py
+```
+
+## Watching
+
+Task's built-in watch mode works without a dedicated target:
+
+```bash
+task -w ci                           # re-run ci on file change
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
   - Metrics: metrics.md
   - Contracts: contracts.md
   - Configuration: configuration.md
+  - Commands: commands.md
   - Incremental loading: incremental-loading.md
   - Architecture decisions:
       - Overview: adr/README.md


### PR DESCRIPTION
## Summary

- `Taskfile.yaml`: 224 → 96 lines. Every remaining target composes, injects env, or encodes a default.
- Deleted pure wrappers around `uv run ruff/mypy/pytest/sqlmesh/pre-commit/dagster`.
- New `docs/commands.md` cheatsheet: raw `uv run …` recipes per tool, linked from mkdocs nav + README + CLAUDE.md.
- New `ci` composite: `ruff check + ruff format --check + mypy + pytest + check_secrets.py`.

## `task --list` now

```
ci                  Compose every CI gate: ruff + mypy + pytest + secret scan
clean               Remove build + test + cache artifacts
clean-all           Clean + drop .venv + data/ + .dlt_state/
default             Show available tasks
full-refresh        Run every dlt source + SQLMesh + every Soda check through Dagster
install             Install deps + pre-commit hook (setup + uv sync + hook install)
setup               Create .venv + bootstrap .env from .env.example
streamlit           Launch Databox Explorer (cd app/ + streamlit run main.py)
verify              Smoke full-refresh — DATABOX_SMOKE=1 caps each source to 5 items
dagster:dev         Launch Dagster UI with DAGSTER_HOME + PYTHONPATH + definitions path
db:reset            Delete local DuckDB files (MotherDuck dbs must be dropped manually)
```

## Validation

- `wc -l Taskfile.yaml` = 96 (≤100 target)
- `task --list` readable (11 targets, all with useful `desc:`)
- `task setup` still works on a warm checkout
- `mkdocs build --strict` clean with `docs/commands.md` in nav
- README Quickstart + Development blocks updated; CLAUDE.md Task block updated

## Test plan

- [x] Taskfile line count
- [x] task --list readable
- [x] task setup exits clean
- [x] mkdocs --strict clean
- [ ] CI green

Closes `ticket:taskfile-trim` (Phase 1, `initiative:scaffold-polish`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)