### PR TITLE
feat(staging): generate trivial-rename staging SQL from Soda contracts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,6 @@
 *.toml text
 *.txt text
 *.sh text eol=lf
+
+# Generated staging SQL — regenerate via `task staging:generate`.
+transforms/main/models/*/staging/stg_*.sql linguist-generated=true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,6 +97,20 @@ jobs:
             --base origin/${{ github.base_ref }} \
             --pr-body-file /tmp/pr_body.txt
 
+  staging-codegen-drift:
+    name: Staging codegen drift
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - name: Install
+        run: uv sync --all-extras --dev
+      - name: Check generated staging SQL matches contracts
+        run: uv run python scripts/generate_staging.py --check
+
   soda-validate:
     name: Soda contract structure
     runs-on: ubuntu-latest

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -27,7 +27,7 @@ tasks:
       - scripts/setup_pre_commit.sh
 
   ci:
-    desc: "Compose every CI gate: ruff + mypy + pytest + secret scan"
+    desc: "Compose every CI gate: ruff + mypy + pytest + secret scan + staging-codegen drift"
     deps: [install]
     cmds:
       - "{{.VENV_DIR}}/bin/ruff check ."
@@ -35,6 +35,19 @@ tasks:
       - "{{.VENV_DIR}}/bin/mypy . --ignore-missing-imports"
       - "{{.VENV_DIR}}/bin/pytest"
       - python scripts/check_secrets.py .
+      - python scripts/generate_staging.py --check
+
+  staging:generate:
+    desc: "Regenerate trivial-rename staging SQL from Soda contracts"
+    deps: [install]
+    cmds:
+      - python scripts/generate_staging.py
+
+  staging:check:
+    desc: "Fail if committed staging SQL drifts from contracts"
+    deps: [install]
+    cmds:
+      - python scripts/generate_staging.py --check
 
   full-refresh:
     desc: "Run every dlt source + SQLMesh + every Soda check through Dagster"

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -1,0 +1,63 @@
+# Staging Codegen
+
+Trivial-rename staging models (`transforms/main/models/*/staging/stg_*.sql`) are generated from their Soda contracts rather than hand-written. The codegen exists because the staging layer is dominated by `SELECT old_col AS new_col` from a raw catalog — writing each one by hand scales poorly as sources grow.
+
+Non-trivial staging (joins, UNION ALL, derived columns, filters) opts out with a skip marker and stays hand-maintained.
+
+## How it runs
+
+- `task staging:generate` — regenerate every non-skipped staging SQL in place.
+- `task staging:check` — exit `1` if any committed staging SQL differs from what the generator would emit. Run in CI as the `staging-codegen-drift` job.
+
+The generator lives in `databox.quality.staging_codegen`; `scripts/generate_staging.py` is a thin CLI wrapper.
+
+## Contract extension
+
+A codegen-driven staging contract adds two keys on top of the standard Soda layout:
+
+```yaml
+dataset: databox/ebird_staging/stg_ebird_hotspots
+source_table: raw_ebird.main.hotspots
+description: Staging model for eBird birding hotspots
+
+columns:
+  - name: location_id
+    source_column: loc_id        # optional; defaults to `name` when omitted
+    checks:
+      - missing:
+          must_be: 0
+  - name: latitude
+    source_column: lat
+    data_type: DOUBLE            # optional; emits `lat::DOUBLE AS latitude` when present
+  - name: country_code           # identity — no rename, no cast
+```
+
+Rules applied by the template:
+
+| contract fields | emitted SQL |
+| --- | --- |
+| `name: x` | `x` |
+| `name: x`, `source_column: y` | `y AS x` |
+| `name: x`, `data_type: T` | `x::T AS x` |
+| `name: x`, `source_column: y`, `data_type: T` | `y::T AS x` |
+
+`description` becomes the model's `description '...'`. Columns are emitted in the order they appear in the contract. The grant list is hardcoded to `staging_reader`; if a staging model needs a different grant, use the escape hatch.
+
+## Escape hatch
+
+Add a `-- staging-codegen: skip` header on the first three lines of the target SQL and the generator will leave that file alone. Use it when the staging model needs behavior the template cannot express — UNION ALL, CASE, EXTRACT, joins, filters.
+
+Example: `transforms/main/models/ebird/staging/stg_ebird_observations.sql` uses the skip marker because it UNIONs `recent_observations` and `notable_observations` and derives `observation_year/month/day/hour` columns.
+
+When a skipped model's contract also omits `source_table`, that is fine — the generator checks for the skip marker before requiring the key.
+
+## When to use which
+
+| fits codegen | needs escape hatch |
+| --- | --- |
+| pure column renames | joins across raw tables |
+| cast-only transforms | UNION ALL |
+| identity passthrough | CASE / EXTRACT / other derivations |
+|  | row filtering |
+
+The default should be codegen. Reach for the escape hatch only when the template genuinely cannot express the staging shape.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ nav:
   - Analytics examples: analytics-examples.md
   - Metrics: metrics.md
   - Contracts: contracts.md
+  - Staging codegen: staging.md
   - Configuration: configuration.md
   - Commands: commands.md
   - Incremental loading: incremental-loading.md

--- a/packages/databox/databox/quality/staging_codegen.py
+++ b/packages/databox/databox/quality/staging_codegen.py
@@ -1,0 +1,163 @@
+"""Generate trivial-rename staging SQL from Soda contracts.
+
+A staging contract carries enough shape (source table + per-column source
+name + optional cast type) to emit the equivalent `SELECT ... FROM raw_*`.
+Non-trivial staging (joins, derivations, UNION, filters) opts out with a
+`-- staging-codegen: skip` header on the target SQL file.
+
+Contract extensions (additive — does not break schema-contract-gate):
+
+    dataset: databox/<schema>/<table>
+    source_table: raw_<source>.main.<table>
+    description: <free text>
+    columns:
+      - name: target_col
+        source_column: raw_col        # optional; defaults to `name`
+        data_type: double             # optional; emits CAST if present
+        checks: ...
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
+CONTRACTS_DIR = Path("soda/contracts")
+MODELS_DIR = Path("transforms/main/models")
+TEMPLATE_DIR = Path("scripts/templates")
+SKIP_MARKER = "staging-codegen: skip"
+
+
+@dataclass
+class Column:
+    name: str
+    source_column: str
+    data_type: str | None
+
+
+@dataclass
+class StagingModel:
+    contract_path: Path
+    target_path: Path
+    schema: str
+    table: str
+    description: str
+    source_table: str
+    columns: list[Column]
+
+
+def _template_env() -> Environment:
+    return Environment(
+        loader=FileSystemLoader(str(TEMPLATE_DIR)),
+        keep_trailing_newline=True,
+        undefined=StrictUndefined,
+    )
+
+
+def _target_for_dataset(dataset: str) -> tuple[str, str, Path] | None:
+    if "/" not in dataset:
+        return None
+    parts = dataset.split("/")
+    if len(parts) < 3 or not parts[1].endswith("_staging"):
+        return None
+    schema, table = parts[1], parts[2]
+    target = MODELS_DIR / schema.split("_staging")[0] / "staging" / f"{table}.sql"
+    return schema, table, target
+
+
+def parse_contract(path: Path) -> StagingModel | None:
+    """Parse a staging contract into a StagingModel, or None if it is not a staging contract."""
+    doc: dict[str, Any] = yaml.safe_load(path.read_text()) or {}
+    target_info = _target_for_dataset(doc.get("dataset", ""))
+    if target_info is None:
+        return None
+    schema, table, target_path = target_info
+    source_table = doc.get("source_table")
+    if not source_table:
+        if is_skipped(target_path):
+            return None
+        raise ValueError(f"{path}: staging contract missing 'source_table' key")
+    cols_raw = doc.get("columns") or []
+    columns = [
+        Column(
+            name=str(c["name"]),
+            source_column=str(c.get("source_column") or c["name"]),
+            data_type=str(c["data_type"]) if c.get("data_type") else None,
+        )
+        for c in cols_raw
+        if isinstance(c, dict) and "name" in c
+    ]
+    return StagingModel(
+        contract_path=path,
+        target_path=target_path,
+        schema=schema,
+        table=table,
+        description=doc.get("description", f"Staging model {schema}.{table}"),
+        source_table=source_table,
+        columns=columns,
+    )
+
+
+def render(model: StagingModel, env: Environment | None = None) -> str:
+    jenv: Environment = env if env is not None else _template_env()
+    tmpl = jenv.get_template("staging.sql.j2")
+    return tmpl.render(
+        contract_path=str(model.contract_path).replace("\\", "/"),
+        schema=model.schema,
+        table=model.table,
+        description=model.description.replace("'", "''"),
+        source_table=model.source_table,
+        columns=model.columns,
+    )
+
+
+def is_skipped(target: Path) -> bool:
+    if not target.exists():
+        return False
+    head = target.read_text().splitlines()[:3]
+    return any(SKIP_MARKER in line for line in head)
+
+
+def discover_models(contracts_root: Path = CONTRACTS_DIR) -> list[StagingModel]:
+    out: list[StagingModel] = []
+    for p in sorted(contracts_root.rglob("*.yaml")):
+        if "_staging/" not in str(p):
+            continue
+        model = parse_contract(p)
+        if model is not None:
+            out.append(model)
+    return out
+
+
+def generate_all(contracts_root: Path = CONTRACTS_DIR) -> list[tuple[Path, str]]:
+    """Render every non-skipped staging model. Returns list of (target_path, rendered_sql)."""
+    env = _template_env()
+    results: list[tuple[Path, str]] = []
+    for model in discover_models(contracts_root):
+        if is_skipped(model.target_path):
+            continue
+        results.append((model.target_path, render(model, env)))
+    return results
+
+
+def check_drift(contracts_root: Path = CONTRACTS_DIR) -> list[Path]:
+    """Return paths whose committed SQL differs from what the generator would emit."""
+    drifted: list[Path] = []
+    for target, rendered in generate_all(contracts_root):
+        current = target.read_text() if target.exists() else ""
+        if current != rendered:
+            drifted.append(target)
+    return drifted
+
+
+def write_all(contracts_root: Path = CONTRACTS_DIR) -> list[Path]:
+    written: list[Path] = []
+    for target, rendered in generate_all(contracts_root):
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(rendered)
+        written.append(target)
+    return written

--- a/scripts/generate_staging.py
+++ b/scripts/generate_staging.py
@@ -1,0 +1,48 @@
+"""Staging-model codegen CLI — thin wrapper over databox.quality.staging_codegen.
+
+Usage:
+    python scripts/generate_staging.py              # regenerate staging SQL in place
+    python scripts/generate_staging.py --check      # exit 1 if committed SQL drifts
+
+Exit: 0 clean/written · 1 drift · 2 invocation error.
+See docs/staging.md for the contract extension and the escape hatch.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from databox.quality.staging_codegen import check_drift, write_all
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--check", action="store_true", help="fail if committed SQL drifts")
+    a = p.parse_args(argv)
+    try:
+        if a.check:
+            drifted = check_drift()
+            if drifted:
+                print("Staging SQL drifted from contracts:", file=sys.stderr)
+                for t in drifted:
+                    print(f"  - {t}", file=sys.stderr)
+                print(
+                    "\nRun `task staging:generate` to regenerate, "
+                    "or add `-- staging-codegen: skip` to the target SQL if it is hand-maintained.",
+                    file=sys.stderr,
+                )
+                return 1
+            print("Staging SQL matches contracts.")
+            return 0
+        written = write_all()
+        for t in written:
+            print(f"wrote {t}")
+        return 0
+    except (ValueError, RuntimeError) as exc:
+        print(f"staging-codegen error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/templates/staging.sql.j2
+++ b/scripts/templates/staging.sql.j2
@@ -1,0 +1,14 @@
+-- Generated from {{ contract_path }} by scripts/generate_staging.py.
+-- DO NOT EDIT by hand — run `task staging:generate` to regenerate.
+MODEL (
+  name {{ schema }}.{{ table }},
+  kind FULL,
+  description '{{ description }}',
+  grants (select_ = ['staging_reader'])
+);
+
+SELECT
+{%- for c in columns %}
+    {% if c.data_type %}{{ c.source_column }}::{{ c.data_type }} AS {{ c.name }}{% elif c.source_column != c.name %}{{ c.source_column }} AS {{ c.name }}{% else %}{{ c.name }}{% endif %}{% if not loop.last %},{% endif %}
+{%- endfor %}
+FROM {{ source_table }}

--- a/soda/contracts/ebird_staging/stg_ebird_hotspots.yaml
+++ b/soda/contracts/ebird_staging/stg_ebird_hotspots.yaml
@@ -1,22 +1,41 @@
 dataset: databox/ebird_staging/stg_ebird_hotspots
+source_table: raw_ebird.main.hotspots
+description: Staging model for eBird birding hotspots
 
 columns:
   - name: location_id
+    source_column: loc_id
     checks:
       - missing:
           must_be: 0
       - duplicate:
           must_be: 0
   - name: location_name
+    source_column: loc_name
     checks:
       - missing:
           must_be: 0
   - name: country_code
   - name: state_code
+    source_column: subnational1_code
+  - name: county_code
+    source_column: subnational2_code
   - name: latitude
+    source_column: lat
+    data_type: DOUBLE
   - name: longitude
-  - name: total_species_count
+    source_column: lng
+    data_type: DOUBLE
   - name: latest_observation_datetime
+    source_column: latest_obs_dt
+    data_type: TIMESTAMP
+  - name: total_species_count
+    source_column: num_species_all_time
+  - name: region_code
+    source_column: _region_code
+  - name: loaded_at
+    source_column: _loaded_at
+    data_type: TIMESTAMP
 
 checks:
   - row_count:

--- a/soda/contracts/ebird_staging/stg_ebird_taxonomy.yaml
+++ b/soda/contracts/ebird_staging/stg_ebird_taxonomy.yaml
@@ -1,4 +1,6 @@
 dataset: databox/ebird_staging/stg_ebird_taxonomy
+source_table: raw_ebird.main.taxonomy
+description: Staging model for eBird taxonomy reference data
 
 columns:
   - name: species_code
@@ -8,17 +10,26 @@ columns:
       - duplicate:
           must_be: 0
   - name: common_name
+    source_column: com_name
     checks:
       - missing:
           must_be: 0
   - name: scientific_name
+    source_column: sci_name
     checks:
       - missing:
           must_be: 0
-  - name: taxonomic_category
   - name: taxonomic_order
+    source_column: taxon_order
+  - name: taxonomic_category
+    source_column: category
   - name: family_common_name
+    source_column: family_com_name
   - name: family_scientific_name
+    source_column: family_sci_name
+  - name: loaded_at
+    source_column: _loaded_at
+    data_type: TIMESTAMP
 
 checks:
   - row_count:

--- a/soda/contracts/noaa_staging/stg_noaa_daily_weather.yaml
+++ b/soda/contracts/noaa_staging/stg_noaa_daily_weather.yaml
@@ -1,11 +1,11 @@
 dataset: databox/noaa_staging/stg_noaa_daily_weather
+source_table: raw_noaa.main.daily_weather
+description: Staging model for NOAA daily weather observations
 
 columns:
-  - name: station
-    checks:
-      - missing:
-          must_be: 0
   - name: observation_date
+    source_column: date
+    data_type: DATE
     checks:
       - missing:
           must_be: 0
@@ -13,7 +13,19 @@ columns:
     checks:
       - missing:
           must_be: 0
+  - name: station
+    checks:
+      - missing:
+          must_be: 0
   - name: value
+    data_type: DOUBLE
+  - name: attributes
+  - name: source
+  - name: location_id
+    source_column: _location_id
+  - name: loaded_at
+    source_column: _loaded_at
+    data_type: TIMESTAMP
 
 checks:
   - row_count:

--- a/soda/contracts/noaa_staging/stg_noaa_stations.yaml
+++ b/soda/contracts/noaa_staging/stg_noaa_stations.yaml
@@ -1,21 +1,41 @@
 dataset: databox/noaa_staging/stg_noaa_stations
+source_table: raw_noaa.main.stations
+description: Staging model for NOAA weather stations
 
 columns:
   - name: station_id
+    source_column: id
     checks:
       - missing:
           must_be: 0
       - duplicate:
           must_be: 0
   - name: station_name
+    source_column: name
     checks:
       - missing:
           must_be: 0
   - name: latitude
+    data_type: DOUBLE
   - name: longitude
+    data_type: DOUBLE
   - name: elevation
+    data_type: DOUBLE
+  - name: elevation_unit
   - name: min_date
+    source_column: mindate
+    data_type: DATE
   - name: max_date
+    source_column: maxdate
+    data_type: DATE
+  - name: data_coverage
+    source_column: datacoverage
+    data_type: DOUBLE
+  - name: location_id
+    source_column: _location_id
+  - name: loaded_at
+    source_column: _loaded_at
+    data_type: TIMESTAMP
 
 checks:
   - row_count:

--- a/soda/contracts/usgs_staging/stg_usgs_daily_values.yaml
+++ b/soda/contracts/usgs_staging/stg_usgs_daily_values.yaml
@@ -1,19 +1,33 @@
 dataset: databox/usgs_staging/stg_usgs_daily_values
+source_table: raw_usgs.main.daily_values
+description: Staging model for USGS daily streamflow and gage observations
 
 columns:
   - name: site_no
     checks:
       - missing:
           must_be: 0
-  - name: observation_date
-    checks:
-      - missing:
-          must_be: 0
+  - name: site_name
+  - name: latitude
+  - name: longitude
   - name: parameter_cd
     checks:
       - missing:
           must_be: 0
+  - name: parameter_name
+  - name: unit_cd
+  - name: observation_date
+    data_type: DATE
+    checks:
+      - missing:
+          must_be: 0
   - name: value
+  - name: qualifier
+  - name: state_cd
+    source_column: _state_cd
+  - name: loaded_at
+    source_column: _loaded_at
+    data_type: TIMESTAMP
 
 checks:
   - row_count:

--- a/soda/contracts/usgs_staging/stg_usgs_sites.yaml
+++ b/soda/contracts/usgs_staging/stg_usgs_sites.yaml
@@ -1,4 +1,6 @@
 dataset: databox/usgs_staging/stg_usgs_sites
+source_table: raw_usgs.main.sites
+description: Staging model for USGS monitoring site metadata
 
 columns:
   - name: site_no
@@ -6,8 +8,19 @@ columns:
       - missing:
           must_be: 0
   - name: site_name
+  - name: site_type
   - name: latitude
   - name: longitude
+  - name: county_cd
+  - name: state_cd
+  - name: huc_cd
+  - name: drainage_area_sqmi
+    source_column: drain_area_va
+  - name: begin_date
+  - name: end_date
+  - name: loaded_at
+    source_column: _loaded_at
+    data_type: TIMESTAMP
 
 checks:
   - row_count:

--- a/tests/test_staging_codegen.py
+++ b/tests/test_staging_codegen.py
@@ -1,0 +1,192 @@
+"""Unit tests for databox.quality.staging_codegen.
+
+Exercises the contract parser, the renderer, and the skip-marker logic.
+End-to-end regeneration against real contracts is covered by the
+`staging-codegen-drift` CI job.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from databox.quality.staging_codegen import (
+    Column,
+    StagingModel,
+    check_drift,
+    is_skipped,
+    parse_contract,
+    render,
+)
+
+
+def _write(path: Path, body: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+    return path
+
+
+# --------------------------------------------------------------------------- #
+# parse_contract
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_full_contract(tmp_path: Path) -> None:
+    p = _write(
+        tmp_path / "soda/contracts/foo_staging/stg_foo_bar.yaml",
+        """
+dataset: databox/foo_staging/stg_foo_bar
+source_table: raw_foo.main.bar
+description: Hello
+columns:
+  - name: id
+  - name: created_at
+    source_column: _created_at
+    data_type: TIMESTAMP
+  - name: latitude
+    data_type: DOUBLE
+""",
+    )
+    model = parse_contract(p)
+    assert model is not None
+    assert model.schema == "foo_staging"
+    assert model.table == "stg_foo_bar"
+    assert model.source_table == "raw_foo.main.bar"
+    assert model.description == "Hello"
+    assert [c.name for c in model.columns] == ["id", "created_at", "latitude"]
+    assert model.columns[0].source_column == "id"
+    assert model.columns[0].data_type is None
+    assert model.columns[1].source_column == "_created_at"
+    assert model.columns[1].data_type == "TIMESTAMP"
+
+
+def test_parse_non_staging_returns_none(tmp_path: Path) -> None:
+    p = _write(
+        tmp_path / "soda/contracts/foo/fct_bar.yaml",
+        "dataset: databox/foo/fct_bar\ncolumns: []\n",
+    )
+    assert parse_contract(p) is None
+
+
+def test_parse_missing_source_table_raises(tmp_path: Path) -> None:
+    p = _write(
+        tmp_path / "soda/contracts/foo_staging/stg_x.yaml",
+        "dataset: databox/foo_staging/stg_x\ncolumns: []\n",
+    )
+    with pytest.raises(ValueError, match="source_table"):
+        parse_contract(p)
+
+
+# --------------------------------------------------------------------------- #
+# render
+# --------------------------------------------------------------------------- #
+
+
+def _model(columns: list[Column]) -> StagingModel:
+    return StagingModel(
+        contract_path=Path("soda/contracts/foo_staging/stg_foo.yaml"),
+        target_path=Path("transforms/main/models/foo/staging/stg_foo.sql"),
+        schema="foo_staging",
+        table="stg_foo",
+        description="Foo staging",
+        source_table="raw_foo.main.bar",
+        columns=columns,
+    )
+
+
+def test_render_identity_column() -> None:
+    sql = render(_model([Column("id", "id", None)]))
+    assert "    id\n" in sql
+    assert "FROM raw_foo.main.bar" in sql
+
+
+def test_render_rename_only() -> None:
+    sql = render(_model([Column("location_id", "loc_id", None)]))
+    assert "    loc_id AS location_id\n" in sql
+
+
+def test_render_cast_with_rename() -> None:
+    sql = render(_model([Column("latitude", "lat", "DOUBLE")]))
+    assert "    lat::DOUBLE AS latitude\n" in sql
+
+
+def test_render_cast_identity_name() -> None:
+    sql = render(_model([Column("value", "value", "DOUBLE")]))
+    assert "    value::DOUBLE AS value\n" in sql
+
+
+def test_render_trailing_comma_rules() -> None:
+    sql = render(
+        _model(
+            [
+                Column("a", "a", None),
+                Column("b", "b", None),
+                Column("c", "c", None),
+            ]
+        )
+    )
+    lines = [line.rstrip() for line in sql.splitlines()]
+    assert "    a," in lines
+    assert "    b," in lines
+    assert "    c" in lines
+    assert "    c," not in lines
+
+
+def test_render_header_comment_and_model() -> None:
+    sql = render(_model([Column("id", "id", None)]))
+    assert sql.startswith("-- Generated from soda/contracts/foo_staging/stg_foo.yaml")
+    assert "MODEL (\n  name foo_staging.stg_foo,\n  kind FULL," in sql
+    assert "grants (select_ = ['staging_reader'])" in sql
+
+
+def test_render_escapes_single_quote_in_description() -> None:
+    model = _model([Column("id", "id", None)])
+    model.description = "It's staging"
+    assert "description 'It''s staging'" in render(model)
+
+
+# --------------------------------------------------------------------------- #
+# is_skipped / check_drift
+# --------------------------------------------------------------------------- #
+
+
+def test_is_skipped_recognises_marker(tmp_path: Path) -> None:
+    p = _write(tmp_path / "a.sql", "-- staging-codegen: skip\nMODEL (...)\n")
+    assert is_skipped(p)
+
+
+def test_is_skipped_false_without_marker(tmp_path: Path) -> None:
+    p = _write(tmp_path / "a.sql", "MODEL (...)\n")
+    assert not is_skipped(p)
+
+
+def test_is_skipped_false_on_missing_file(tmp_path: Path) -> None:
+    assert not is_skipped(tmp_path / "nope.sql")
+
+
+def test_check_drift_clean_after_write(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Anchor the codegen at a temp workspace and verify a regenerated file is drift-free.
+    contracts_root = tmp_path / "soda" / "contracts"
+    _write(
+        contracts_root / "foo_staging" / "stg_foo.yaml",
+        """
+dataset: databox/foo_staging/stg_foo
+source_table: raw_foo.main.bar
+description: Foo
+columns:
+  - name: id
+""",
+    )
+    models_root = tmp_path / "transforms" / "main" / "models"
+    models_root.mkdir(parents=True)
+
+    import databox.quality.staging_codegen as mod
+
+    monkeypatch.setattr(mod, "CONTRACTS_DIR", contracts_root)
+    monkeypatch.setattr(mod, "MODELS_DIR", models_root)
+    # Template path is relative to CWD; chdir into repo root (it owns the template).
+    monkeypatch.chdir(Path(__file__).parent.parent)
+
+    written = mod.write_all(contracts_root)
+    assert len(written) == 1
+    assert check_drift(contracts_root) == []

--- a/transforms/main/models/ebird/staging/stg_ebird_hotspots.sql
+++ b/transforms/main/models/ebird/staging/stg_ebird_hotspots.sql
@@ -1,3 +1,5 @@
+-- Generated from soda/contracts/ebird_staging/stg_ebird_hotspots.yaml by scripts/generate_staging.py.
+-- DO NOT EDIT by hand — run `task staging:generate` to regenerate.
 MODEL (
   name ebird_staging.stg_ebird_hotspots,
   kind FULL,
@@ -13,8 +15,8 @@ SELECT
     subnational2_code AS county_code,
     lat::DOUBLE AS latitude,
     lng::DOUBLE AS longitude,
-    latest_obs_dt::timestamp AS latest_observation_datetime,
+    latest_obs_dt::TIMESTAMP AS latest_observation_datetime,
     num_species_all_time AS total_species_count,
     _region_code AS region_code,
-    _loaded_at::timestamp AS loaded_at
+    _loaded_at::TIMESTAMP AS loaded_at
 FROM raw_ebird.main.hotspots

--- a/transforms/main/models/ebird/staging/stg_ebird_observations.sql
+++ b/transforms/main/models/ebird/staging/stg_ebird_observations.sql
@@ -1,3 +1,4 @@
+-- staging-codegen: skip (UNION ALL across recent + notable, derived date parts)
 MODEL (
   name ebird_staging.stg_ebird_observations,
   kind FULL,

--- a/transforms/main/models/ebird/staging/stg_ebird_taxonomy.sql
+++ b/transforms/main/models/ebird/staging/stg_ebird_taxonomy.sql
@@ -1,3 +1,5 @@
+-- Generated from soda/contracts/ebird_staging/stg_ebird_taxonomy.yaml by scripts/generate_staging.py.
+-- DO NOT EDIT by hand — run `task staging:generate` to regenerate.
 MODEL (
   name ebird_staging.stg_ebird_taxonomy,
   kind FULL,
@@ -13,5 +15,5 @@ SELECT
     category AS taxonomic_category,
     family_com_name AS family_common_name,
     family_sci_name AS family_scientific_name,
-    _loaded_at::timestamp AS loaded_at
+    _loaded_at::TIMESTAMP AS loaded_at
 FROM raw_ebird.main.taxonomy

--- a/transforms/main/models/noaa/staging/stg_noaa_daily_weather.sql
+++ b/transforms/main/models/noaa/staging/stg_noaa_daily_weather.sql
@@ -1,3 +1,5 @@
+-- Generated from soda/contracts/noaa_staging/stg_noaa_daily_weather.yaml by scripts/generate_staging.py.
+-- DO NOT EDIT by hand — run `task staging:generate` to regenerate.
 MODEL (
   name noaa_staging.stg_noaa_daily_weather,
   kind FULL,
@@ -9,10 +11,7 @@ SELECT
     date::DATE AS observation_date,
     datatype,
     station,
-    CASE
-        WHEN value IS NOT NULL THEN CAST(value AS DOUBLE)
-        ELSE NULL
-    END AS value,
+    value::DOUBLE AS value,
     attributes,
     source,
     _location_id AS location_id,

--- a/transforms/main/models/noaa/staging/stg_noaa_stations.sql
+++ b/transforms/main/models/noaa/staging/stg_noaa_stations.sql
@@ -1,3 +1,5 @@
+-- Generated from soda/contracts/noaa_staging/stg_noaa_stations.yaml by scripts/generate_staging.py.
+-- DO NOT EDIT by hand — run `task staging:generate` to regenerate.
 MODEL (
   name noaa_staging.stg_noaa_stations,
   kind FULL,

--- a/transforms/main/models/usgs/staging/stg_usgs_daily_values.sql
+++ b/transforms/main/models/usgs/staging/stg_usgs_daily_values.sql
@@ -1,3 +1,5 @@
+-- Generated from soda/contracts/usgs_staging/stg_usgs_daily_values.yaml by scripts/generate_staging.py.
+-- DO NOT EDIT by hand — run `task staging:generate` to regenerate.
 MODEL (
   name usgs_staging.stg_usgs_daily_values,
   kind FULL,

--- a/transforms/main/models/usgs/staging/stg_usgs_sites.sql
+++ b/transforms/main/models/usgs/staging/stg_usgs_sites.sql
@@ -1,3 +1,5 @@
+-- Generated from soda/contracts/usgs_staging/stg_usgs_sites.yaml by scripts/generate_staging.py.
+-- DO NOT EDIT by hand — run `task staging:generate` to regenerate.
 MODEL (
   name usgs_staging.stg_usgs_sites,
   kind FULL,


### PR DESCRIPTION
## Summary

Ticket: `ticket:staging-model-codegen` (Phase 1 of `initiative:scaffold-polish`).

Staging SQL whose only job is `SELECT old_col AS new_col FROM raw_*` is now generated from the matching Soda contract instead of hand-written. Six of the seven staging models become generated artifacts; `stg_ebird_observations` keeps the skip marker because it UNIONs recent + notable observations and derives date parts.

- `databox.quality.staging_codegen` — parser + renderer + drift check
- `scripts/generate_staging.py` — thin CLI (write / `--check` modes)
- `scripts/templates/staging.sql.j2` — Jinja2 template
- `task staging:generate` / `task staging:check`
- New `staging-codegen-drift` CI job fails the build if committed `stg_*.sql` drifts
- `.gitattributes` marks generated SQL `linguist-generated=true`
- `docs/staging.md` documents the contract extension + escape hatch

Contract extensions are additive (new `source_table` top-level key, new `source_column` / `data_type` per column). The schema-contract gate sees them as additive — no breaking change.

## Test plan

- [x] `uv run pytest tests/test_staging_codegen.py` — 14 new tests pass
- [x] `uv run pytest` — 50 tests pass overall
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run mypy packages/ --ignore-missing-imports` — clean
- [x] `uv run python scripts/generate_staging.py --check` — no drift
- [x] `uv run python scripts/check_secrets.py .` — clean
- [x] `uv run mkdocs build --strict` — clean
- [ ] CI `staging-codegen-drift` job green
- [ ] CI `schema-contract-gate` sees contract additions as additive

🤖 Generated with [Claude Code](https://claude.com/claude-code)