### PR TITLE
feat(lint): enforce per-source directory layout in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,6 +97,20 @@ jobs:
             --base origin/${{ github.base_ref }} \
             --pr-body-file /tmp/pr_body.txt
 
+  source-layout-lint:
+    name: Source layout lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - name: Install
+        run: uv sync --all-extras --dev
+      - name: Verify every source follows the standard layout
+        run: uv run python scripts/check_source_layout.py
+
   staging-codegen-drift:
     name: Staging codegen drift
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,8 @@ Raw SQLMesh / Dagster / pytest invocations: [docs/commands.md](docs/commands.md)
 
 ## Adding a New Data Source
 
+The required on-disk layout is codified in [`docs/source-layout.md`](docs/source-layout.md) and enforced by `task check:layout` (and the `source-layout-lint` CI job). Every new source must satisfy that layout — the lint will flag anything missing.
+
 1. **Create source package**: `packages/databox-sources/databox_sources/<source>/`
    - `source.py`: dlt resources using `@dlt.source` / `@dlt.resource`
    - `config.yaml`: pipeline config
@@ -105,14 +107,16 @@ Raw SQLMesh / Dagster / pytest invocations: [docs/commands.md](docs/commands.md)
 2. **Add transform models**: `transforms/main/models/<source>/`
    - Copy structure from `transforms/main/models/ebird/` as a template
    - Read from `raw_<source>.*` (dlt writes here)
-   - Staging models write to `<source>_staging.*`
+   - Staging models write to `<source>_staging.*` (trivial-rename staging → generated via `task staging:generate`)
    - Mart models write to `<source>.*`
 
 3. **Add Soda contracts**: `soda/contracts/<source>_staging/` and `soda/contracts/<source>/`
 
-4. **Wire Dagster assets** in `packages/databox/databox/orchestration/definitions.py`
+4. **Add a domain file**: `packages/databox/databox/orchestration/domains/<source>.py` — wire assets, asset checks, daily job, schedule
 
 5. **Add secrets to `.env`**: `API_KEY_<SOURCE>=your_key_here`
+
+6. **Verify**: `task check:layout` → should show `✓ <source>`
 
 ## Architecture Decisions
 

--- a/README.md
+++ b/README.md
@@ -213,10 +213,14 @@ docs/
 
 scripts/
 ├── generate_docs.py       # Data-dictionary generator
-└── schema_gate.py         # CI breaking-change gate
+├── generate_staging.py    # Staging-SQL codegen from Soda contracts
+├── schema_gate.py         # CI breaking-change gate
+└── check_source_layout.py # Source-layout convention lint
 
 data/                      # DuckDB files (gitignored)
 ```
+
+Adding a source? See [docs/source-layout.md](docs/source-layout.md) for the required on-disk shape (enforced in CI by `source-layout-lint`).
 
 ## Published artifacts
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -49,6 +49,12 @@ tasks:
     cmds:
       - python scripts/generate_staging.py --check
 
+  check:layout:
+    desc: "Verify every source follows the standard directory layout"
+    deps: [install]
+    cmds:
+      - python scripts/check_source_layout.py
+
   full-refresh:
     desc: "Run every dlt source + SQLMesh + every Soda check through Dagster"
     deps: [install]

--- a/docs/source-layout.md
+++ b/docs/source-layout.md
@@ -1,0 +1,81 @@
+# Source Layout Convention
+
+Every registered dlt source in Databox follows the same on-disk shape. Consistency means new sources cost a predictable amount to add, drift is visible to CI, and the [new-source generator](#new-source-generator) has a precise target.
+
+`scripts/check_source_layout.py` enforces the convention — it runs as the `source-layout-lint` CI job on every PR and as `task check:layout` locally.
+
+## The shape
+
+For a source named `<name>` (e.g. `ebird`, `noaa`, `usgs`):
+
+```
+packages/databox-sources/databox_sources/<name>/
+  ├── source.py              # dlt @source / @resource definitions
+  └── config.yaml            # pipeline config (dataset, schedule hints)
+
+transforms/main/models/<name>/
+  ├── staging/
+  │   └── stg_*.sql          # at least one staging model
+  └── marts/
+      └── (fct_*|dim_*).sql  # at least one mart model
+
+soda/contracts/<name>_staging/
+  └── *.yaml                 # at least one staging contract
+
+soda/contracts/<name>/
+  └── *.yaml                 # at least one mart contract
+
+packages/databox/databox/orchestration/domains/<name>.py
+                             # Dagster assets, schedules, asset checks
+```
+
+Intermediate models under `transforms/main/models/<name>/intermediate/` are optional — the lint does not require them.
+
+## What the linter checks
+
+The script walks `packages/databox-sources/databox_sources/*/` looking for directories that contain a `source.py`. For each, it asserts the seven components above exist and contain at least one matching file.
+
+Output format is line-oriented so CI logs stay diffable:
+
+```
+  ✓ ebird
+  ✗ noaa
+      missing: soda/contracts/noaa/*.yaml
+  ✓ usgs
+
+2 ok · 0 skipped · 1 failing (of 3)
+```
+
+`--json` emits the same data in machine-readable form for generator tooling.
+
+## Escape hatch: `scaffold-lint: skip`
+
+Experimental or in-flight sources that don't yet satisfy the full layout can opt out by adding a line within the first 10 lines of `source.py`:
+
+```python
+# scaffold-lint: skip=experimental
+```
+
+The reason after `=` is free text — common values: `experimental`, `in-flight`, `wip-domain-refactor`. Skipped sources appear in the lint output marked `~ (skipped: <reason>)` but do not fail CI.
+
+Do not use the skip marker to silence drift in a finished source. If the lint complains about an existing source, the right answer is almost always "add the missing file" — the convention exists because each component has a concrete job.
+
+## Why each file is required
+
+| Component | Why it is required |
+| --- | --- |
+| `source.py` | Anchor file — if this doesn't exist, the source isn't loadable |
+| `config.yaml` | Pipeline configuration (dataset name, schedule hints, source-specific options) |
+| `staging/stg_*.sql` | At least one staging model turning raw into typed |
+| `marts/(fct_*|dim_*).sql` | At least one consumer-facing mart |
+| `soda/contracts/<name>_staging/` | Data-quality contract for the staging layer |
+| `soda/contracts/<name>/` | Data-quality contract for the mart layer |
+| `domains/<name>.py` | Dagster wiring — assets, schedules, asset checks |
+
+Dropping any of these creates a source that half-works. The lint makes that state unshippable.
+
+## New-source generator
+
+`ticket:new-source-generator` (Phase 2) will scaffold this layout given just the source name. Whatever the linter requires is what the generator creates — the two stay in lockstep.
+
+Until that ticket lands, adding a source by hand means copying the shape above. See `CLAUDE.md` for the current manual checklist.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -62,6 +62,7 @@ nav:
   - Metrics: metrics.md
   - Contracts: contracts.md
   - Staging codegen: staging.md
+  - Source layout: source-layout.md
   - Configuration: configuration.md
   - Commands: commands.md
   - Incremental loading: incremental-loading.md

--- a/scripts/check_source_layout.py
+++ b/scripts/check_source_layout.py
@@ -1,0 +1,153 @@
+"""Verify every registered dlt source follows the standard directory layout.
+
+Required components per source `<name>`:
+
+- `packages/databox-sources/databox_sources/<name>/source.py`
+- `packages/databox-sources/databox_sources/<name>/config.yaml`
+- `transforms/main/models/<name>/staging/` with at least one `stg_*.sql`
+- `transforms/main/models/<name>/marts/` with at least one `fct_*.sql` or `dim_*.sql`
+- `soda/contracts/<name>_staging/` with at least one `*.yaml`
+- `soda/contracts/<name>/` with at least one `*.yaml`
+- `packages/databox/databox/orchestration/domains/<name>.py`
+
+An experimental / in-flight source can opt out by placing a
+`# scaffold-lint: skip=<reason>` line in its `source.py` header (within
+the first 10 lines). The source is then reported but not treated as a
+failure.
+
+Usage:
+    python scripts/check_source_layout.py           # text output, exit 1 on error
+    python scripts/check_source_layout.py --json    # machine-readable output
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+SOURCES_DIR = Path("packages/databox-sources/databox_sources")
+MODELS_DIR = Path("transforms/main/models")
+CONTRACTS_DIR = Path("soda/contracts")
+DOMAINS_DIR = Path("packages/databox/databox/orchestration/domains")
+SKIP_MARKER = "scaffold-lint: skip="
+SKIP_HEADER_LINES = 10
+
+
+@dataclass
+class SourceReport:
+    name: str
+    missing: list[str] = field(default_factory=list)
+    skipped: bool = False
+    skip_reason: str | None = None
+
+    @property
+    def ok(self) -> bool:
+        return self.skipped or not self.missing
+
+
+def discover_sources(root: Path = SOURCES_DIR) -> list[str]:
+    out: list[str] = []
+    for child in sorted(root.iterdir()) if root.exists() else []:
+        if not child.is_dir() or child.name.startswith("_") or child.name.startswith("."):
+            continue
+        if (child / "source.py").exists():
+            out.append(child.name)
+    return out
+
+
+def _skip_marker(source_py: Path) -> str | None:
+    if not source_py.exists():
+        return None
+    for line in source_py.read_text().splitlines()[:SKIP_HEADER_LINES]:
+        idx = line.find(SKIP_MARKER)
+        if idx >= 0:
+            return line[idx + len(SKIP_MARKER) :].strip().split()[0] or "unspecified"
+    return None
+
+
+def _has_match(directory: Path, globs: list[str]) -> bool:
+    if not directory.exists():
+        return False
+    return any(directory.glob(g) for g in globs if list(directory.glob(g)))
+
+
+def check_source(name: str) -> SourceReport:
+    src_pkg = SOURCES_DIR / name
+    source_py = src_pkg / "source.py"
+    report = SourceReport(name=name)
+    marker = _skip_marker(source_py)
+    if marker is not None:
+        report.skipped = True
+        report.skip_reason = marker
+        return report
+
+    if not source_py.exists():
+        report.missing.append(str(source_py))
+    if not (src_pkg / "config.yaml").exists():
+        report.missing.append(str(src_pkg / "config.yaml"))
+
+    staging = MODELS_DIR / name / "staging"
+    if not _has_match(staging, ["stg_*.sql"]):
+        report.missing.append(f"{staging}/stg_*.sql")
+
+    marts = MODELS_DIR / name / "marts"
+    if not _has_match(marts, ["fct_*.sql", "dim_*.sql"]):
+        report.missing.append(f"{marts}/(fct_*|dim_*).sql")
+
+    staging_contracts = CONTRACTS_DIR / f"{name}_staging"
+    if not _has_match(staging_contracts, ["*.yaml"]):
+        report.missing.append(f"{staging_contracts}/*.yaml")
+
+    mart_contracts = CONTRACTS_DIR / name
+    if not _has_match(mart_contracts, ["*.yaml"]):
+        report.missing.append(f"{mart_contracts}/*.yaml")
+
+    domain_file = DOMAINS_DIR / f"{name}.py"
+    if not domain_file.exists():
+        report.missing.append(str(domain_file))
+
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    a = p.parse_args(argv)
+
+    sources = discover_sources()
+    if not sources:
+        print(
+            "source-layout-lint error: no sources found under packages/databox-sources/",
+            file=sys.stderr,
+        )
+        return 2
+
+    reports = [check_source(name) for name in sources]
+    failing = [r for r in reports if not r.ok]
+
+    if a.json:
+        print(json.dumps({"sources": [asdict(r) for r in reports]}, indent=2))
+    else:
+        for r in reports:
+            if r.skipped:
+                print(f"  ~ {r.name} (skipped: {r.skip_reason})")
+            elif r.ok:
+                print(f"  ✓ {r.name}")
+            else:
+                print(f"  ✗ {r.name}")
+                for m in r.missing:
+                    print(f"      missing: {m}")
+        total = len(reports)
+        skipped = sum(1 for r in reports if r.skipped)
+        failed = len(failing)
+        passed = total - skipped - failed
+        print(f"\n{passed} ok · {skipped} skipped · {failed} failing (of {total})")
+
+    return 1 if failing else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_check_source_layout.py
+++ b/tests/test_check_source_layout.py
@@ -1,0 +1,127 @@
+"""Unit tests for scripts/check_source_layout.py.
+
+Exercises the linter against a synthetic source tree in tmp_path. Uses
+monkeypatch to rebind the module's path constants at the Path level so
+the production script logic is exactly what gets exercised.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+SCRIPT = Path(__file__).parent.parent / "scripts" / "check_source_layout.py"
+
+
+def _load_module():
+    if "check_source_layout" in sys.modules:
+        return sys.modules["check_source_layout"]
+    spec = importlib.util.spec_from_file_location("check_source_layout", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["check_source_layout"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _scaffold_complete_source(root: Path, name: str) -> None:
+    src = root / "packages/databox-sources/databox_sources" / name
+    src.mkdir(parents=True)
+    (src / "source.py").write_text("# dlt source\n")
+    (src / "config.yaml").write_text("name: x\n")
+
+    (root / f"transforms/main/models/{name}/staging").mkdir(parents=True)
+    (root / f"transforms/main/models/{name}/staging/stg_{name}_x.sql").write_text("-- stg\n")
+    (root / f"transforms/main/models/{name}/marts").mkdir(parents=True)
+    (root / f"transforms/main/models/{name}/marts/fct_{name}_x.sql").write_text("-- fct\n")
+
+    (root / f"soda/contracts/{name}_staging").mkdir(parents=True)
+    (root / f"soda/contracts/{name}_staging/stg_{name}_x.yaml").write_text("dataset: x\n")
+    (root / f"soda/contracts/{name}").mkdir(parents=True)
+    (root / f"soda/contracts/{name}/fct_{name}_x.yaml").write_text("dataset: x\n")
+
+    (root / "packages/databox/databox/orchestration/domains").mkdir(parents=True, exist_ok=True)
+    (root / f"packages/databox/databox/orchestration/domains/{name}.py").write_text("# domain\n")
+
+
+def _rebind_paths(module, root: Path) -> None:
+    module.SOURCES_DIR = root / "packages/databox-sources/databox_sources"
+    module.MODELS_DIR = root / "transforms/main/models"
+    module.CONTRACTS_DIR = root / "soda/contracts"
+    module.DOMAINS_DIR = root / "packages/databox/databox/orchestration/domains"
+
+
+def test_complete_source_passes(tmp_path: Path) -> None:
+    module = _load_module()
+    _scaffold_complete_source(tmp_path, "foo")
+    _rebind_paths(module, tmp_path)
+    assert module.discover_sources(module.SOURCES_DIR) == ["foo"]
+    report = module.check_source("foo")
+    assert report.ok
+    assert report.missing == []
+
+
+def test_missing_mart_contract_fails(tmp_path: Path) -> None:
+    module = _load_module()
+    _scaffold_complete_source(tmp_path, "foo")
+    _rebind_paths(module, tmp_path)
+    # Drop mart contract.
+    (tmp_path / "soda/contracts/foo/fct_foo_x.yaml").unlink()
+    report = module.check_source("foo")
+    assert not report.ok
+    assert any("soda/contracts/foo/*.yaml" in m for m in report.missing)
+
+
+def test_missing_domain_file_fails(tmp_path: Path) -> None:
+    module = _load_module()
+    _scaffold_complete_source(tmp_path, "foo")
+    _rebind_paths(module, tmp_path)
+    (tmp_path / "packages/databox/databox/orchestration/domains/foo.py").unlink()
+    report = module.check_source("foo")
+    assert not report.ok
+    assert any("domains/foo.py" in m for m in report.missing)
+
+
+def test_skip_marker_bypasses_checks(tmp_path: Path) -> None:
+    module = _load_module()
+    (tmp_path / "packages/databox-sources/databox_sources/expr").mkdir(parents=True)
+    (tmp_path / "packages/databox-sources/databox_sources/expr/source.py").write_text(
+        "# scaffold-lint: skip=experimental\n# dlt source\n"
+    )
+    _rebind_paths(module, tmp_path)
+    report = module.check_source("expr")
+    assert report.ok
+    assert report.skipped
+    assert report.skip_reason == "experimental"
+
+
+def test_discover_ignores_private_and_files(tmp_path: Path) -> None:
+    module = _load_module()
+    base = tmp_path / "packages/databox-sources/databox_sources"
+    base.mkdir(parents=True)
+    (base / "_shared").mkdir()
+    (base / "_shared/source.py").write_text("x")
+    (base / "foo").mkdir()
+    (base / "foo/source.py").write_text("x")
+    (base / "bar.py").write_text("# module, not a source package\n")
+    assert module.discover_sources(base) == ["foo"]
+
+
+def test_stg_glob_matches_any_stg_file(tmp_path: Path) -> None:
+    module = _load_module()
+    _scaffold_complete_source(tmp_path, "foo")
+    _rebind_paths(module, tmp_path)
+    # Rename the existing file to a different stg_* name — still matches glob.
+    stg_dir = tmp_path / "transforms/main/models/foo/staging"
+    (stg_dir / "stg_foo_x.sql").rename(stg_dir / "stg_foo_other.sql")
+    assert module.check_source("foo").ok
+
+
+def test_mart_accepts_dim_file(tmp_path: Path) -> None:
+    module = _load_module()
+    _scaffold_complete_source(tmp_path, "foo")
+    _rebind_paths(module, tmp_path)
+    marts_dir = tmp_path / "transforms/main/models/foo/marts"
+    (marts_dir / "fct_foo_x.sql").rename(marts_dir / "dim_foo_x.sql")
+    assert module.check_source("foo").ok


### PR DESCRIPTION
## Summary

Ticket: `ticket:source-layout-convention` (Phase 1 of `initiative:scaffold-polish`).

Codifies the seven-component per-source shape that Phase 1 converged on, and enforces it via `scripts/check_source_layout.py` in CI. Any new source that lands without the full layout fails the `source-layout-lint` job with a clear `missing: <path>` list.

- `scripts/check_source_layout.py` — lint (text + `--json` modes)
- `task check:layout` — local invocation
- New `source-layout-lint` CI job on every PR
- `docs/source-layout.md` — convention doc, published in the docs site
- `README.md` + `CLAUDE.md` — point at the doc and the lint
- Escape hatch: `# scaffold-lint: skip=<reason>` in `source.py` for experimental sources
- 7 unit tests covering the full matrix (complete / missing-mart / missing-domain / skip-marker / discover-ignores-private / stg-glob / dim-accepted)

Lint passes cleanly on current `ebird` / `noaa` / `usgs`.

## Test plan

- [x] `uv run pytest tests/test_check_source_layout.py` — 7 pass
- [x] `uv run pytest` — 57 total pass
- [x] `uv run ruff check . && uv run ruff format --check .`
- [x] `uv run mypy packages/ --ignore-missing-imports` — clean
- [x] `uv run python scripts/check_source_layout.py` → 3 ok · 0 skipped · 0 failing
- [x] `uv run mkdocs build --strict` — clean
- [ ] CI `source-layout-lint` job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)