### PR TITLE
ci(routing): path-based CI to skip heavy matrix on docs/source-only PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,10 @@
 name: CI
 
+# Path-based routing: docs-only + loom-only PRs skip the heavy matrix; source-
+# specific PRs run only that source's tests. Pushes to main always run the full
+# matrix, and any change to `.github/workflows/**` forces the full matrix to
+# prevent routing bugs from hiding regressions. See docs/ci.md for details.
+
 on:
   push:
     branches: [main]
@@ -12,8 +17,86 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Classify changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      docs: ${{ steps.filter.outputs.docs }}
+      src_ebird: ${{ steps.filter.outputs.src_ebird }}
+      src_noaa: ${{ steps.filter.outputs.src_noaa }}
+      src_usgs: ${{ steps.filter.outputs.src_usgs }}
+      cross_cutting: ${{ steps.filter.outputs.cross_cutting }}
+      ci_config: ${{ steps.filter.outputs.ci_config }}
+      needs_full: ${{ steps.compose.outputs.needs_full }}
+      needs_any_source: ${{ steps.compose.outputs.needs_any_source }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
+        id: filter
+        with:
+          filters: |
+            docs:
+              - 'docs/**'
+              - '*.md'
+              - 'mkdocs.yml'
+            src_ebird:
+              - 'packages/databox-sources/databox_sources/ebird/**'
+              - 'packages/databox-sources/tests/ebird/**'
+              - 'transforms/main/models/ebird/**'
+              - 'soda/contracts/ebird/**'
+              - 'soda/contracts/ebird_staging/**'
+              - 'packages/databox/databox/orchestration/domains/ebird.py'
+            src_noaa:
+              - 'packages/databox-sources/databox_sources/noaa/**'
+              - 'packages/databox-sources/tests/noaa/**'
+              - 'transforms/main/models/noaa/**'
+              - 'soda/contracts/noaa/**'
+              - 'soda/contracts/noaa_staging/**'
+              - 'packages/databox/databox/orchestration/domains/noaa.py'
+            src_usgs:
+              - 'packages/databox-sources/databox_sources/usgs/**'
+              - 'packages/databox-sources/tests/usgs/**'
+              - 'transforms/main/models/usgs/**'
+              - 'soda/contracts/usgs/**'
+              - 'soda/contracts/usgs_staging/**'
+              - 'packages/databox/databox/orchestration/domains/usgs.py'
+            cross_cutting:
+              - 'packages/databox/**'
+              - 'packages/databox-sources/databox_sources/__init__.py'
+              - 'packages/databox-sources/databox_sources/_*.py'
+              - 'packages/databox-sources/databox_sources/base.py'
+              - 'packages/databox-sources/databox_sources/registry.py'
+              - 'scripts/**'
+              - 'tests/**'
+              - 'transforms/main/models/analytics/**'
+              - 'soda/contracts/analytics/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'Taskfile.yaml'
+              - '.pre-commit-config.yaml'
+            ci_config:
+              - '.github/workflows/**'
+      - id: compose
+        run: |
+          if [[ "${{ github.event_name }}" == "push" \
+              || "${{ steps.filter.outputs.cross_cutting }}" == "true" \
+              || "${{ steps.filter.outputs.ci_config }}" == "true" ]]; then
+            echo "needs_full=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "needs_full=false" >> "$GITHUB_OUTPUT"
+          fi
+          if [[ "${{ steps.filter.outputs.src_ebird }}" == "true" \
+              || "${{ steps.filter.outputs.src_noaa }}" == "true" \
+              || "${{ steps.filter.outputs.src_usgs }}" == "true" ]]; then
+            echo "needs_any_source=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "needs_any_source=false" >> "$GITHUB_OUTPUT"
+          fi
+
   lint:
     name: Ruff (lint + format)
+    needs: changes
+    if: needs.changes.outputs.needs_full == 'true' || needs.changes.outputs.needs_any_source == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
@@ -30,6 +113,8 @@ jobs:
 
   typecheck:
     name: mypy
+    needs: changes
+    if: needs.changes.outputs.needs_full == 'true' || needs.changes.outputs.needs_any_source == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
@@ -42,8 +127,10 @@ jobs:
       - name: mypy
         run: uv run mypy packages/ --ignore-missing-imports
 
-  tests:
-    name: pytest
+  tests-core:
+    name: pytest (core)
+    needs: changes
+    if: needs.changes.outputs.needs_full == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
@@ -53,11 +140,61 @@ jobs:
           cache-dependency-glob: uv.lock
       - name: Install
         run: uv sync --all-extras --dev
-      - name: pytest
-        run: uv run pytest
+      - name: pytest core (tests/ + packages/databox)
+        run: uv run pytest tests packages/databox --override-ini="testpaths=tests packages/databox"
+
+  tests-ebird:
+    name: pytest (ebird)
+    needs: changes
+    if: needs.changes.outputs.needs_full == 'true' || needs.changes.outputs.src_ebird == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - name: Install
+        run: uv sync --all-extras --dev
+      - name: pytest ebird
+        run: uv run pytest packages/databox-sources/tests/ebird --override-ini="testpaths=packages/databox-sources/tests/ebird"
+
+  tests-noaa:
+    name: pytest (noaa)
+    needs: changes
+    if: needs.changes.outputs.needs_full == 'true' || needs.changes.outputs.src_noaa == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - name: Install
+        run: uv sync --all-extras --dev
+      - name: pytest noaa
+        run: uv run pytest packages/databox-sources/tests/noaa --override-ini="testpaths=packages/databox-sources/tests/noaa"
+
+  tests-usgs:
+    name: pytest (usgs)
+    needs: changes
+    if: needs.changes.outputs.needs_full == 'true' || needs.changes.outputs.src_usgs == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - name: Install
+        run: uv sync --all-extras --dev
+      - name: pytest usgs
+        run: uv run pytest packages/databox-sources/tests/usgs --override-ini="testpaths=packages/databox-sources/tests/usgs"
 
   sqlmesh-lint:
     name: SQLMesh lint
+    needs: changes
+    if: needs.changes.outputs.needs_full == 'true' || needs.changes.outputs.needs_any_source == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
@@ -70,15 +207,46 @@ jobs:
       - name: sqlmesh lint
         run: uv run sqlmesh --paths transforms/main lint
 
+  source-layout-lint:
+    name: Source layout lint
+    # Always required — cheap, and the layout is the invariant for scaling sources.
+    if: github.event_name == 'pull_request' || github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - name: Install
+        run: uv sync --all-extras --dev
+      - name: Verify every source follows the standard layout
+        run: uv run python scripts/check_source_layout.py
+
+  staging-codegen-drift:
+    name: Staging codegen drift
+    needs: changes
+    if: needs.changes.outputs.needs_full == 'true' || needs.changes.outputs.needs_any_source == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - name: Install
+        run: uv sync --all-extras --dev
+      - name: Check generated staging SQL matches contracts
+        run: uv run python scripts/generate_staging.py --check
+
   schema-contract-gate:
     name: Schema contract gate
-    runs-on: ubuntu-latest
-    # Only meaningful on PRs — pushes to main have no base ref to diff against.
+    # Always required on PRs — the gate is cheap and protects downstream consumers.
     if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
         with:
-          # Need full history so `origin/main` resolves for the diff base.
           fetch-depth: 0
       - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
         with:
@@ -97,36 +265,10 @@ jobs:
             --base origin/${{ github.base_ref }} \
             --pr-body-file /tmp/pr_body.txt
 
-  source-layout-lint:
-    name: Source layout lint
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
-      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
-        with:
-          enable-cache: true
-          cache-dependency-glob: uv.lock
-      - name: Install
-        run: uv sync --all-extras --dev
-      - name: Verify every source follows the standard layout
-        run: uv run python scripts/check_source_layout.py
-
-  staging-codegen-drift:
-    name: Staging codegen drift
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
-      - uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
-        with:
-          enable-cache: true
-          cache-dependency-glob: uv.lock
-      - name: Install
-        run: uv sync --all-extras --dev
-      - name: Check generated staging SQL matches contracts
-        run: uv run python scripts/generate_staging.py --check
-
   soda-validate:
     name: Soda contract structure
+    needs: changes
+    if: needs.changes.outputs.needs_full == 'true' || needs.changes.outputs.needs_any_source == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,79 @@
+# CI Routing
+
+Databox CI runs per-PR and on every push to `main`. Most changes only touch one source or just the docs — the workflow uses path-based routing so a docs typo or an `ebird`-only change doesn't drag the full test matrix through a cold install.
+
+The routing logic lives in `.github/workflows/ci.yaml`; this page explains *why* it's shaped the way it is and what to expect when a PR runs.
+
+## The classifier
+
+A first job, `Classify changed paths`, runs on every event. It uses [`dorny/paths-filter`](https://github.com/dorny/paths-filter) to label the diff with a set of boolean outputs:
+
+| Output | Matches |
+| --- | --- |
+| `docs` | `docs/**`, any root `*.md`, `mkdocs.yml` |
+| `src_ebird` | `packages/databox-sources/databox_sources/ebird/**`, `packages/databox-sources/tests/ebird/**`, `transforms/main/models/ebird/**`, `soda/contracts/ebird{,_staging}/**`, `domains/ebird.py` |
+| `src_noaa` | same shape, scoped to `noaa` |
+| `src_usgs` | same shape, scoped to `usgs` |
+| `cross_cutting` | `packages/databox/**`, shared source plumbing (`__init__.py`, `base.py`, `registry.py`, `_*.py`), `scripts/**`, top-level `tests/**`, analytics models & contracts, `pyproject.toml`, `uv.lock`, `Taskfile.yaml`, `.pre-commit-config.yaml` |
+| `ci_config` | `.github/workflows/**` |
+
+Two composed outputs are derived from those:
+
+- `needs_full` — `true` on every push to `main`, on any `cross_cutting` change, or on any `ci_config` change
+- `needs_any_source` — `true` when any `src_*` filter matched
+
+## Routing rules
+
+| Job | Runs when |
+| --- | --- |
+| `lint` (ruff), `typecheck` (mypy) | `needs_full \|\| needs_any_source` |
+| `tests-core` | `needs_full` only (runs `tests/` + `packages/databox`) |
+| `tests-ebird` / `tests-noaa` / `tests-usgs` | `needs_full \|\| src_<source>` |
+| `sqlmesh-lint` | `needs_full \|\| needs_any_source` |
+| `staging-codegen-drift` | `needs_full \|\| needs_any_source` |
+| `soda-validate` | `needs_full \|\| needs_any_source` |
+| `source-layout-lint` | always (cheap; the layout is the scaling invariant) |
+| `schema-contract-gate` | always on `pull_request` (protects downstream consumers) |
+
+The always-on jobs are intentional — they cost a fraction of a minute each and enforce invariants that must not drift silently.
+
+## What each routing decision looks like
+
+**Docs-only PR** (`docs/**` or `*.md`):
+`source-layout-lint` + `schema-contract-gate` only. Everything else skips.
+
+**Single-source PR** (e.g. `ebird` only):
+`lint`, `typecheck`, `sqlmesh-lint`, `staging-codegen-drift`, `soda-validate`, `tests-ebird`, `source-layout-lint`, `schema-contract-gate`. `tests-core`, `tests-noaa`, `tests-usgs` skip.
+
+**Cross-cutting PR** (anything in `packages/databox/**`, `scripts/**`, etc.):
+Full matrix.
+
+**CI config PR** (`.github/workflows/**`):
+Full matrix — routing bugs must be visible before they're merged.
+
+**Push to `main`**:
+Full matrix, always. The event_name check in `needs_full` enforces this independently of the filter.
+
+## Why `tests-core` is gated on `needs_full` only
+
+`tests/` and `packages/databox/**/tests/**` exercise the shared infrastructure — config, orchestration, quality engine, schema gate, staging codegen. A source-only PR can't reach any of that code path, so running it would only burn minutes.
+
+Per-source tests live under `packages/databox-sources/tests/<source>/` and are wired to their matching `src_<source>` filter. The filter includes the test directory so a test-only change still triggers the source's job.
+
+## When routing is wrong
+
+The classifier is an approximation. If a PR changes only `soda/contracts/ebird/` but should also re-run NOAA tests (e.g. because a shared utility silently regressed), `needs_full` won't flip.
+
+The guardrails:
+
+1. **`.github/workflows/**` forces `needs_full`.** Any routing refinement flows through the workflow file itself, and the refinement PR sees the full matrix.
+2. **Pushes to `main` always run the full matrix.** Per-PR routing is the fast path; the post-merge run is the safety net.
+3. **Any shared library change lives under `packages/databox/**` or `scripts/**`**, both in `cross_cutting`. If you find yourself sharing logic across sources without putting it there, the routing will start lying — move it.
+
+If you add a new source, three things change:
+
+- Add a `src_<name>` filter block mirroring the existing three
+- Add a `tests-<name>` job gated on `needs_full || src_<name>`
+- Update the `needs_any_source` compose step to include the new filter output
+
+The `source-layout-lint` job will already enforce the directory shape.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
   - Contracts: contracts.md
   - Staging codegen: staging.md
   - Source layout: source-layout.md
+  - CI routing: ci.md
   - Configuration: configuration.md
   - Commands: commands.md
   - Incremental loading: incremental-loading.md


### PR DESCRIPTION
## Summary
- Classify changed paths with `dorny/paths-filter@v3` (docs / src_{ebird,noaa,usgs} / cross_cutting / ci_config) plus composed `needs_full` and `needs_any_source` outputs.
- Split `pytest` into `tests-core` (gated on `needs_full`) + `tests-ebird`/`tests-noaa`/`tests-usgs` (gated on `needs_full \|\| src_<name>`). Per-source tests already split under `packages/databox-sources/tests/<source>/`.
- Gate `lint`, `typecheck`, `sqlmesh-lint`, `staging-codegen-drift`, `soda-validate` on `needs_full \|\| needs_any_source`.
- Keep `source-layout-lint` and `schema-contract-gate` always-on — cheap, and protect invariants that must not drift silently.
- Pushes to `main` and any edit under `.github/workflows/**` force the full matrix.
- New `docs/ci.md` explains the routing table and how to extend it when adding a new source.

## Test plan
- [ ] CI run on this PR exercises `ci_config` → `needs_full=true` → full matrix
- [ ] `source-layout-lint` + `schema-contract-gate` run
- [ ] Subsequent docs-only / source-only PRs skip the irrelevant jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)