### PR TITLE
feat(scaffold): one-command fork rebrand via scaffold.yaml + task init

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,21 @@ Dagster is the one entrypoint — individual pipeline runs, quality checks,
 schedules, and sensors all happen as assets in the same DAG. See
 [ADR-0005](docs/adr/0005-dagster-as-sole-orchestrator.md).
 
+## Forking
+
+Databox is designed to be forked. After cloning:
+
+```bash
+task init -- \
+  --name Weatherbox --slug weatherbox \
+  --org your-org --repo weatherbox \
+  --site-url https://your-org.github.io/weatherbox/
+```
+
+`task init` reads `scaffold.yaml`, rewrites every project-identity reference across README/mkdocs/docs/LICENSE/pyproject, and is a no-op on second run. The three example sources (eBird / NOAA / USGS) stay wired so the whole pipeline is green on day one — delete or replace them at your own pace.
+
+See **[docs/template.md](docs/template.md)** for the full list of what's covered, what stays unchanged (Python package name, external deps), and how to extend the scaffold.
+
 ## Backends
 
 Flip between local and cloud via environment variables; the SQL never

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -55,6 +55,12 @@ tasks:
     cmds:
       - python scripts/check_source_layout.py
 
+  init:
+    desc: "Rebrand a fresh fork — rewrite project identity from scaffold.yaml (see docs/template.md)"
+    deps: [install]
+    cmds:
+      - python scripts/bootstrap.py {{.CLI_ARGS}}
+
   full-refresh:
     desc: "Run every dlt source + SQLMesh + every Soda check through Dagster"
     deps: [install]

--- a/docs/template.md
+++ b/docs/template.md
@@ -1,0 +1,83 @@
+# Forking Databox
+
+Databox is designed as a *scaffold*, not a finished product. The three example sources (eBird, NOAA, USGS) demonstrate the pattern — they stay wired end-to-end after you fork, so you can see data flow through dlt → SQLMesh → Soda → Dagster → MkDocs on day one.
+
+This page covers the one-command rebrand that makes the fork yours.
+
+## The rename
+
+```bash
+task init -- \
+  --name Weatherbox \
+  --slug weatherbox \
+  --org example-org \
+  --repo weatherbox \
+  --site-url https://example-org.github.io/weatherbox/ \
+  --copyright-holder "Alice Example"
+```
+
+`task init` delegates to `scripts/bootstrap.py`, which:
+
+1. Reads the current identity from `scaffold.yaml`.
+2. Applies your overrides to compute a new identity.
+3. Substitutes every recorded old value for its replacement across the files listed in `scaffold.yaml`'s `bootstrap.includes`.
+4. Writes the new values back to `scaffold.yaml`.
+
+Running it twice with the same arguments is a no-op.
+
+## What gets rewritten
+
+| File / glob | What changes |
+| --- | --- |
+| `README.md` | CI/docs badge URLs, site link, `# Databox` heading, prose brand mentions |
+| `mkdocs.yml` | `site_name`, `site_url`, `repo_url`, `repo_name` |
+| `pyproject.toml` (root) | Workspace name, description string |
+| `LICENSE` | Copyright holder line |
+| `CLAUDE.md` | Title + project-identity sentences |
+| `docs/*.md`, `docs/adr/*.md` | GitHub hyperlinks, brand name mentions |
+| `scripts/generate_docs.py` | `REPO_BLOB_URL` constant used in dictionary links |
+
+Auto-generated files under `docs/dictionary/` are *not* rewritten directly — their generator reads the updated URL, so the next `python scripts/generate_docs.py` regenerates them with the new identity.
+
+## What does NOT change
+
+- **Python package name.** `packages/databox/` stays `databox`, because `from databox.config import …` imports appear in every source package. Renaming the Python package would cascade through every source, test, and Dagster wiring — far outside the scope of a one-command rebrand.
+- **External dependencies.** `dagster-sqlmesh` continues to pull from the upstream fork. If you fork that too, edit `packages/databox/pyproject.toml` manually.
+- **The three example sources.** eBird, NOAA, USGS stay as working examples. Delete them (or replace them) at your own pace — the layout lint (`task check:layout`) enforces the shape new sources must follow.
+- **`.loom/` history.** The `.loom/` records document how this scaffold was built; they are historical artifacts, not project identity.
+
+## Verifying the rename
+
+After `task init`, run the full gates:
+
+```bash
+task ci              # ruff + mypy + pytest + drift check
+task check:layout    # every source still satisfies the layout
+task verify          # smoke full-refresh (DATABOX_SMOKE=1) — all three sources through Dagster
+```
+
+Then a sanity grep:
+
+```bash
+rg -n 'Doctacon|doctacon\.github\.io'  # should return only .loom/ history
+```
+
+If anything remains outside `.loom/`, either add the file to `scaffold.yaml`'s `bootstrap.includes` or edit it by hand and open an issue — the scaffold aims to keep `task init` comprehensive.
+
+## Adding your own templated values
+
+`scaffold.yaml` is editable. Add a new field under `project:` or `github:`, then teach `scripts/bootstrap.py` how to substitute it by extending `compute_substitutions`. The rule: substitutions must be *specific enough not to collide with Python identifiers*. Full URLs, qualified paths like `{org}/{repo}`, composite tokens like `{slug}-workspace`, and the capitalized brand name are all safe. Bare lowercase slugs are not.
+
+## Deleting the example sources
+
+Out of scope for `task init` — that command only renames. To remove a source:
+
+1. Delete `packages/databox-sources/databox_sources/<source>/`
+2. Delete `packages/databox-sources/tests/<source>/`
+3. Delete `transforms/main/models/<source>/`
+4. Delete `soda/contracts/<source>/` and `soda/contracts/<source>_staging/`
+5. Delete `packages/databox/databox/orchestration/domains/<source>.py`
+6. Remove any analytics models or contracts that reference it
+7. Run `task check:layout` — should report no missing layout for the remaining sources
+
+A dedicated `task rm-source <name>` wrapper is planned but not yet shipped.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
   - Contracts: contracts.md
   - Staging codegen: staging.md
   - Source layout: source-layout.md
+  - Forking the scaffold: template.md
   - CI routing: ci.md
   - Configuration: configuration.md
   - Commands: commands.md

--- a/scaffold.yaml
+++ b/scaffold.yaml
@@ -1,0 +1,34 @@
+# Project identity. `scripts/bootstrap.py` reads this file, then rewrites
+# every include-globbed file by substituting the recorded current values for
+# their replacements. `task init` is the user-facing entry point.
+#
+# After a rename: the values below reflect the *new* identity, and the
+# rewritten files match. Run again with the same values → no diff.
+# See docs/template.md for the full workflow.
+
+project:
+  name: Databox
+  slug: databox
+  description: Databox data platform
+  copyright_holder: Connor Lough
+
+github:
+  org: Doctacon
+  repo: databox
+
+docs:
+  site_url: https://doctacon.github.io/databox/
+
+bootstrap:
+  # Files rewritten by `task init`. Patterns resolve relative to repo root.
+  # Kept narrow on purpose — Python import paths (e.g. `from databox import …`)
+  # must not be touched, since `databox` stays as the Python package name.
+  includes:
+    - README.md
+    - mkdocs.yml
+    - pyproject.toml
+    - LICENSE
+    - CLAUDE.md
+    - docs/*.md
+    - docs/adr/*.md
+    - scripts/generate_docs.py

--- a/scripts/bootstrap.py
+++ b/scripts/bootstrap.py
@@ -1,0 +1,213 @@
+"""Rewrite repo identity in-place from `scaffold.yaml`.
+
+Reads the current identity from `scaffold.yaml`, accepts overrides on the CLI,
+computes the set of literal-string substitutions needed to transition the
+committed files from the current identity to the new one, applies them across
+every `bootstrap.includes` pattern, and writes the new values back to
+`scaffold.yaml`.
+
+Design notes:
+
+- Committed files always hold *rendered* values (not Jinja-style tokens). That
+  keeps syntax highlighting, linting, and IDE tooling working in every file.
+- `scaffold.yaml` is the ledger: it remembers what the current values are, so a
+  later `task init --name X` knows what to replace.
+- Replacements are ordered *specific → general*: `Doctacon/databox` must be
+  substituted before `Doctacon` alone, so composite tokens don't fracture.
+- The bare lowercase slug (`databox`) is intentionally NOT replaced — it is
+  also the Python package name. Only composite tokens that cannot collide with
+  Python identifiers (`{slug}-workspace`, full URLs, the capitalized brand)
+  are substituted.
+
+Usage:
+    python scripts/bootstrap.py                              # no-op dry-run
+    python scripts/bootstrap.py --name Weatherbox ...        # apply
+    python scripts/bootstrap.py --check                      # non-zero on drift
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+SCAFFOLD_PATH = ROOT / "scaffold.yaml"
+
+
+@dataclass
+class Identity:
+    name: str
+    slug: str
+    description: str
+    copyright_holder: str
+    org: str
+    repo: str
+    site_url: str
+
+    @classmethod
+    def from_mapping(cls, data: dict) -> Identity:
+        return cls(
+            name=data["project"]["name"],
+            slug=data["project"]["slug"],
+            description=data["project"]["description"],
+            copyright_holder=data["project"]["copyright_holder"],
+            org=data["github"]["org"],
+            repo=data["github"]["repo"],
+            site_url=data["docs"]["site_url"],
+        )
+
+
+def load_scaffold(path: Path = SCAFFOLD_PATH) -> dict:
+    return yaml.safe_load(path.read_text())
+
+
+def overlay(data: dict, **overrides: str | None) -> dict:
+    """Return a new scaffold dict with CLI overrides applied."""
+    out = yaml.safe_load(yaml.safe_dump(data))  # deep copy via round-trip
+    if overrides.get("name"):
+        out["project"]["name"] = overrides["name"]
+    if overrides.get("slug"):
+        out["project"]["slug"] = overrides["slug"]
+    if overrides.get("description"):
+        out["project"]["description"] = overrides["description"]
+    if overrides.get("copyright_holder"):
+        out["project"]["copyright_holder"] = overrides["copyright_holder"]
+    if overrides.get("org"):
+        out["github"]["org"] = overrides["org"]
+    if overrides.get("repo"):
+        out["github"]["repo"] = overrides["repo"]
+    if overrides.get("site_url"):
+        out["docs"]["site_url"] = overrides["site_url"]
+    return out
+
+
+def compute_substitutions(old: Identity, new: Identity) -> list[tuple[str, str]]:
+    """Return (old_str, new_str) pairs, ordered specific→general."""
+    subs: list[tuple[str, str]] = []
+    # Full site URL — most specific, must go first.
+    if old.site_url != new.site_url:
+        subs.append((old.site_url, new.site_url))
+    # Composite GitHub path — catches both github.com/Doctacon/databox and
+    # bare "Doctacon/databox" repo_name references.
+    old_path = f"{old.org}/{old.repo}"
+    new_path = f"{new.org}/{new.repo}"
+    if old_path != new_path:
+        subs.append((old_path, new_path))
+    # Pages-style hostname (lowercase org).
+    old_pages = f"{old.org.lower()}.github.io/{old.repo}"
+    new_pages = f"{new.org.lower()}.github.io/{new.repo}"
+    if old_pages != new_pages:
+        subs.append((old_pages, new_pages))
+    # Workspace name token (safe — does not collide with Python `databox`).
+    old_ws = f"{old.slug}-workspace"
+    new_ws = f"{new.slug}-workspace"
+    if old_ws != new_ws:
+        subs.append((old_ws, new_ws))
+    # Capitalized brand — README heading, mkdocs site_name, site_description.
+    if old.name != new.name:
+        subs.append((old.name, new.name))
+    # Project description string (site_description, pyproject description).
+    if old.description != new.description:
+        subs.append((old.description, new.description))
+    # LICENSE copyright holder line.
+    if old.copyright_holder != new.copyright_holder:
+        subs.append((old.copyright_holder, new.copyright_holder))
+    return subs
+
+
+def resolve_includes(patterns: list[str], root: Path = ROOT) -> list[Path]:
+    out: list[Path] = []
+    seen: set[Path] = set()
+    for pat in patterns:
+        for p in sorted(root.glob(pat)):
+            if p.is_file() and p not in seen:
+                out.append(p)
+                seen.add(p)
+    return out
+
+
+def apply_substitutions(files: list[Path], subs: list[tuple[str, str]]) -> list[tuple[Path, int]]:
+    """Apply substitutions in order. Returns list of (file, hits) for files that changed."""
+    changed: list[tuple[Path, int]] = []
+    for path in files:
+        text = path.read_text()
+        new_text = text
+        total = 0
+        for old, new in subs:
+            if old and old in new_text:
+                total += new_text.count(old)
+                new_text = new_text.replace(old, new)
+        if new_text != text:
+            path.write_text(new_text)
+            changed.append((path, total))
+    return changed
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Rewrite repo identity in-place from scaffold.yaml.")
+    p.add_argument("--name", help="new project brand name (e.g. Weatherbox)")
+    p.add_argument("--slug", help="new project slug (lowercase, e.g. weatherbox)")
+    p.add_argument("--description", help="new project description")
+    p.add_argument("--copyright-holder", dest="copyright_holder", help="new copyright holder")
+    p.add_argument("--org", help="new GitHub org")
+    p.add_argument("--repo", help="new GitHub repo name")
+    p.add_argument("--site-url", dest="site_url", help="new docs site URL")
+    p.add_argument("--check", action="store_true", help="exit 1 if rewrites would occur")
+    args = p.parse_args(argv)
+
+    data = load_scaffold()
+    old = Identity.from_mapping(data)
+    new_data = overlay(
+        data,
+        name=args.name,
+        slug=args.slug,
+        description=args.description,
+        copyright_holder=args.copyright_holder,
+        org=args.org,
+        repo=args.repo,
+        site_url=args.site_url,
+    )
+    new = Identity.from_mapping(new_data)
+
+    subs = compute_substitutions(old, new)
+    if not subs:
+        print("scaffold: identity unchanged, nothing to do")
+        return 0
+
+    includes = data["bootstrap"]["includes"]
+    files = resolve_includes(includes)
+    if not files:
+        print("scaffold: no files matched bootstrap.includes", file=sys.stderr)
+        return 2
+
+    if args.check:
+        # Dry-run: report any file that would change.
+        would_change = []
+        for path in files:
+            text = path.read_text()
+            for old_s, _ in subs:
+                if old_s and old_s in text:
+                    would_change.append(path)
+                    break
+        if would_change:
+            print("scaffold: drift detected in:", file=sys.stderr)
+            for p in would_change:
+                print(f"  - {p.relative_to(ROOT)}", file=sys.stderr)
+            return 1
+        return 0
+
+    changed = apply_substitutions(files, subs)
+    SCAFFOLD_PATH.write_text(yaml.safe_dump(new_data, sort_keys=False))
+
+    print(f"scaffold: applied {len(subs)} substitution(s) across {len(changed)} file(s)")
+    for path, hits in changed:
+        print(f"  {path.relative_to(ROOT)}: {hits} replacement(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_bootstrap.py
+++ b/tests/test_bootstrap.py
@@ -1,0 +1,204 @@
+"""Unit tests for scripts/bootstrap.py.
+
+Exercises the substitution machinery against synthetic file trees — the goal
+is to verify ordering (specific → general), safe non-substitution of bare
+Python-package-name tokens, and idempotency.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+SCRIPT = Path(__file__).parent.parent / "scripts" / "bootstrap.py"
+
+
+def _load_module():
+    if "bootstrap" in sys.modules:
+        return sys.modules["bootstrap"]
+    spec = importlib.util.spec_from_file_location("bootstrap", SCRIPT)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["bootstrap"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _baseline() -> dict:
+    return {
+        "project": {
+            "name": "Databox",
+            "slug": "databox",
+            "description": "Databox data platform",
+            "copyright_holder": "Connor Lough",
+        },
+        "github": {"org": "Doctacon", "repo": "databox"},
+        "docs": {"site_url": "https://doctacon.github.io/databox/"},
+        "bootstrap": {"includes": ["README.md", "pyproject.toml", "LICENSE"]},
+    }
+
+
+def test_no_overrides_produces_empty_substitution_list() -> None:
+    module = _load_module()
+    old = module.Identity.from_mapping(_baseline())
+    new = module.Identity.from_mapping(_baseline())
+    assert module.compute_substitutions(old, new) == []
+
+
+def test_rename_produces_ordered_substitutions() -> None:
+    module = _load_module()
+    old = module.Identity.from_mapping(_baseline())
+    new_data = _baseline()
+    new_data["project"]["name"] = "Weatherbox"
+    new_data["project"]["slug"] = "weatherbox"
+    new_data["github"]["org"] = "example-org"
+    new_data["github"]["repo"] = "weatherbox"
+    new_data["docs"]["site_url"] = "https://example-org.github.io/weatherbox/"
+    new = module.Identity.from_mapping(new_data)
+    subs = module.compute_substitutions(old, new)
+    # Site URL is most specific → must come before composite GitHub path.
+    site_idx = next(i for i, (o, _) in enumerate(subs) if o.startswith("https://"))
+    path_idx = next(i for i, (o, _) in enumerate(subs) if o == "Doctacon/databox")
+    name_idx = next(i for i, (o, _) in enumerate(subs) if o == "Databox")
+    assert site_idx < path_idx < name_idx
+
+
+def test_apply_subs_rewrites_readme(tmp_path: Path) -> None:
+    module = _load_module()
+    readme = tmp_path / "README.md"
+    readme.write_text(
+        "# Databox\n"
+        "[CI](https://github.com/Doctacon/databox/actions)\n"
+        "See https://doctacon.github.io/databox/ for docs.\n"
+    )
+    old = module.Identity.from_mapping(_baseline())
+    new_data = _baseline()
+    new_data["project"]["name"] = "Weatherbox"
+    new_data["project"]["slug"] = "weatherbox"
+    new_data["github"]["org"] = "example-org"
+    new_data["github"]["repo"] = "weatherbox"
+    new_data["docs"]["site_url"] = "https://example-org.github.io/weatherbox/"
+    new = module.Identity.from_mapping(new_data)
+    subs = module.compute_substitutions(old, new)
+    changed = module.apply_substitutions([readme], subs)
+    assert len(changed) == 1
+    out = readme.read_text()
+    assert "# Weatherbox" in out
+    assert "Doctacon" not in out
+    assert "doctacon" not in out
+    assert "https://example-org.github.io/weatherbox/" in out
+
+
+def test_apply_subs_preserves_python_import_name(tmp_path: Path) -> None:
+    """Bare lowercase `databox` (Python package) must NOT be substituted."""
+    module = _load_module()
+    code = tmp_path / "settings.py"
+    code.write_text("from databox.config import settings\nimport databox\n")
+    old = module.Identity.from_mapping(_baseline())
+    new_data = _baseline()
+    new_data["project"]["slug"] = "weatherbox"
+    new_data["github"]["repo"] = "weatherbox"
+    new = module.Identity.from_mapping(new_data)
+    subs = module.compute_substitutions(old, new)
+    module.apply_substitutions([code], subs)
+    assert code.read_text() == "from databox.config import settings\nimport databox\n"
+
+
+def test_apply_subs_rewrites_workspace_name(tmp_path: Path) -> None:
+    module = _load_module()
+    pyproj = tmp_path / "pyproject.toml"
+    pyproj.write_text('[project]\nname = "databox-workspace"\n')
+    old = module.Identity.from_mapping(_baseline())
+    new_data = _baseline()
+    new_data["project"]["slug"] = "weatherbox"
+    new = module.Identity.from_mapping(new_data)
+    subs = module.compute_substitutions(old, new)
+    module.apply_substitutions([pyproj], subs)
+    assert 'name = "weatherbox-workspace"' in pyproj.read_text()
+
+
+def test_idempotent_second_run_with_same_values(tmp_path: Path) -> None:
+    module = _load_module()
+    readme = tmp_path / "README.md"
+    original = "# Weatherbox\nSee https://example-org.github.io/weatherbox/ for docs.\n"
+    readme.write_text(original)
+    new_data = _baseline()
+    new_data["project"]["name"] = "Weatherbox"
+    new_data["project"]["slug"] = "weatherbox"
+    new_data["github"]["org"] = "example-org"
+    new_data["github"]["repo"] = "weatherbox"
+    new_data["docs"]["site_url"] = "https://example-org.github.io/weatherbox/"
+    same = module.Identity.from_mapping(new_data)
+    subs = module.compute_substitutions(same, same)
+    changed = module.apply_substitutions([readme], subs)
+    assert changed == []
+    assert readme.read_text() == original
+
+
+def test_resolve_includes_expands_globs(tmp_path: Path) -> None:
+    module = _load_module()
+    (tmp_path / "docs").mkdir()
+    (tmp_path / "README.md").write_text("x")
+    (tmp_path / "docs" / "a.md").write_text("x")
+    (tmp_path / "docs" / "b.md").write_text("x")
+    files = module.resolve_includes(["README.md", "docs/*.md"], root=tmp_path)
+    assert [p.relative_to(tmp_path).as_posix() for p in files] == [
+        "README.md",
+        "docs/a.md",
+        "docs/b.md",
+    ]
+
+
+def test_overlay_preserves_unset_fields() -> None:
+    module = _load_module()
+    data = _baseline()
+    out = module.overlay(data, name="Weatherbox")
+    assert out["project"]["name"] == "Weatherbox"
+    assert out["project"]["slug"] == "databox"
+    assert out["github"]["org"] == "Doctacon"
+
+
+@pytest.mark.parametrize(
+    "existing,expected_hit",
+    [
+        ("Doctacon/databox", True),
+        ("https://github.com/Doctacon/databox/pull/1", True),
+        ("doctacon.github.io/databox", True),
+        ("databox-workspace", True),
+        ("# Databox", True),
+        ("from databox import foo", False),  # bare lowercase untouched
+        ("databox-sources", False),  # bare lowercase untouched
+    ],
+)
+def test_substitution_coverage(tmp_path: Path, existing: str, expected_hit: bool) -> None:
+    module = _load_module()
+    f = tmp_path / "file.md"
+    f.write_text(existing)
+    old = module.Identity.from_mapping(_baseline())
+    new_data = _baseline()
+    new_data["project"]["name"] = "Weatherbox"
+    new_data["project"]["slug"] = "weatherbox"
+    new_data["github"]["org"] = "example-org"
+    new_data["github"]["repo"] = "weatherbox"
+    new_data["docs"]["site_url"] = "https://example-org.github.io/weatherbox/"
+    new = module.Identity.from_mapping(new_data)
+    subs = module.compute_substitutions(old, new)
+    module.apply_substitutions([f], subs)
+    was_changed = f.read_text() != existing
+    assert was_changed == expected_hit
+
+
+def test_scaffold_yaml_round_trips_identity() -> None:
+    """scaffold.yaml at repo root must parse cleanly into an Identity."""
+    module = _load_module()
+    data = yaml.safe_load((module.ROOT / "scaffold.yaml").read_text())
+    identity = module.Identity.from_mapping(data)
+    assert identity.name
+    assert identity.slug
+    assert identity.org
+    assert identity.repo
+    assert identity.site_url.startswith("https://")


### PR DESCRIPTION
## Summary
- New `scaffold.yaml` at repo root records project identity (name/slug/description/copyright-holder/org/repo/site_url) and the include-glob list of files that carry it.
- New `scripts/bootstrap.py` (`task init`) reads the current identity, accepts CLI overrides, computes ordered specific→general substitutions, and rewrites every included file in-place. Idempotent on second run.
- Safe by construction: only composite/qualified tokens are substituted. Bare lowercase `databox` (the Python package name) is never touched. Covered by a parameterized test.
- `docs/template.md` documents the forker workflow, what stays unchanged, and how to extend the substitution set.
- `README.md` gains a "Forking" section pointing at `task init` + `docs/template.md`.

## What gets rewritten (post-init)
- `README.md` badge URLs + site link + `# Databox` heading + prose brand mentions
- `mkdocs.yml` site_name / site_url / repo_url / repo_name
- Root `pyproject.toml` workspace name + description
- `LICENSE` copyright holder line
- `CLAUDE.md` title + project-identity references
- `docs/*.md`, `docs/adr/*.md` hyperlinks and brand mentions
- `scripts/generate_docs.py` REPO_BLOB_URL

## What doesn't
- Python package name (`packages/databox/` stays `databox`)
- External deps (`dagster-sqlmesh` upstream fork URL)
- Three example sources — stay fully wired for day-one green
- `.loom/` historical records
- Auto-generated `docs/dictionary/**` (regenerated by `generate_docs.py` with the rewritten URL)

## Tests
- 16 new unit tests in `tests/test_bootstrap.py` — ordering, idempotency, bare-lowercase-untouched, scaffold roundtrip, glob resolution, parametrized coverage of target strings
- `task ci` + mkdocs strict build all green

## Test plan
- [ ] CI passes full matrix (cross-cutting change)
- [ ] `uv run python scripts/bootstrap.py --check` on `main` reports no drift
- [ ] Manual: `task init -- --name Weatherbox --slug weatherbox --org example-org --repo weatherbox --site-url https://example-org.github.io/weatherbox/` on a fresh clone produces the expected rewrites and is a no-op on second run

🤖 Generated with [Claude Code](https://claude.com/claude-code)