### PR TITLE
feat(scaffold): new-source generator (task new-source -- <name> --shape {rest,file,database})

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -61,6 +61,12 @@ tasks:
     cmds:
       - python scripts/bootstrap.py {{.CLI_ARGS}}
 
+  new-source:
+    desc: "Scaffold a new dlt source — passes source-layout-lint on first commit (see docs/new-source.md)"
+    deps: [install]
+    cmds:
+      - python scripts/new_source.py {{.CLI_ARGS}}
+
   full-refresh:
     desc: "Run every dlt source + SQLMesh + every Soda check through Dagster"
     deps: [install]

--- a/docs/new-source.md
+++ b/docs/new-source.md
@@ -1,0 +1,124 @@
+# Adding a New Source
+
+The goal is simple: **clone the scaffold, run one command, fill in the TODOs.** From "I want to ingest X" to "I have a running empty pipeline" should be under 60 seconds.
+
+## The generator
+
+```bash
+task new-source -- mysource --shape rest
+```
+
+Shapes:
+
+- `rest` — REST/GraphQL API with a bearer-token env var (default)
+- `file` — filesystem or object-store source (local path, S3, GCS)
+- `database` — SQL database connector with a DSN env var
+
+The generator:
+
+1. Creates the full layout required by [`docs/source-layout.md`](source-layout.md):
+   - `packages/databox-sources/databox_sources/mysource/{__init__.py,source.py,config.yaml}`
+   - `transforms/main/models/mysource/{staging,marts}/.gitkeep`
+   - `soda/contracts/{mysource_staging,mysource}/.gitkeep`
+   - `packages/databox/databox/orchestration/domains/mysource.py`
+2. Adds `mysource` to the imports in `packages/databox/databox/orchestration/definitions.py` and splats its (empty) asset/check lists into the relevant collections.
+3. For `--shape rest`, appends `API_KEY_MYSOURCE=` to `.env.example` if missing.
+4. Prints a 5-step next-steps list.
+
+The generated `source.py` carries a `# scaffold-lint: skip=scaffolded` marker on line 1. That marker tells `scripts/check_source_layout.py` to tolerate the missing staging/mart/contract files while you build out the source — the layout lint still runs, but the scaffold row shows `~ mysource (skipped: scaffolded)` instead of failing.
+
+## Flags
+
+| Flag | Meaning |
+| --- | --- |
+| `--shape {rest,file,database}` | Which template set to use (default `rest`) |
+| `--dry-run` | Print the planned file tree, write nothing |
+| `--force` | Overwrite files that already exist on disk (by default the generator refuses on collision) |
+
+## Naming rules
+
+Source names must match `^[a-z][a-z0-9_]*$`. Reserved names (`analytics`, `_shared`, `base`, `registry`) are rejected.
+
+Pick a short slug — it shows up in table names, dataset names, file paths, and CLI output. `noaa_cdo` is fine; `national_oceanic_and_atmospheric_administration_climate_data_online` is not.
+
+## First-flight walkthrough
+
+```bash
+# 1. Scaffold.
+task new-source -- weather --shape rest
+
+# 2. Verify the layout lint is happy with the scaffolded-skip marker.
+task check:layout
+# Expect:
+#   ~ weather (skipped: scaffolded)
+
+# 3. Fill in source.py — define at least one @dlt.resource, update base URL,
+#    implement pagination. See packages/databox-sources/databox_sources/usgs/source.py
+#    for a canonical example.
+
+# 4. Remove the `# scaffold-lint: skip=scaffolded` marker from source.py.
+#    From here, the layout lint starts checking for staging/mart/contract files.
+
+# 5. Add at least one staging SQL file under transforms/main/models/weather/staging/
+#    (name it `stg_weather_*.sql`). If your source is a "trivial rename" of raw
+#    columns, you can let the staging codegen write it — add a Soda contract under
+#    soda/contracts/weather_staging/ with the full column list, then run:
+task staging:generate
+
+# 6. Add at least one mart under transforms/main/models/weather/marts/
+#    (`fct_*.sql` or `dim_*.sql`). This is your consumer-facing table.
+
+# 7. Add a Soda contract for the mart under soda/contracts/weather/.
+
+# 8. Wire the real Dagster assets in domains/weather.py — see usgs.py as the
+#    canonical reference for shape. Then uncomment and fill in the empty
+#    splat wiring in definitions.py.
+
+# 9. Full run.
+task full-refresh
+```
+
+## What the empty domain stub looks like
+
+```python
+# packages/databox/databox/orchestration/domains/weather.py
+from __future__ import annotations
+
+import dagster as dg
+
+dlt_asset_keys: list[dg.AssetKey] = []
+sqlmesh_asset_keys: list[dg.AssetKey] = []
+asset_checks: list[dg.AssetChecksDefinition] = []
+```
+
+The three list names are the contract that `definitions.py` wires into its splat lists. As you build out the domain, populate each list — don't rename them.
+
+## Idempotency and collisions
+
+Running `task new-source -- weather` twice without `--force` refuses to overwrite. Running with `--force` regenerates every file from the template. Wiring in `definitions.py` is always idempotent — it won't duplicate entries.
+
+For `--dry-run`, the generator prints what it would write (marking any pre-existing paths) and exits without touching the filesystem.
+
+## Extending the generator
+
+Templates live under `scripts/templates/source/`:
+
+```
+scripts/templates/source/
+├── common/
+│   ├── __init__.py.j2
+│   └── domain.py.j2
+├── rest/
+│   ├── source.py.j2
+│   └── config.yaml.j2
+├── file/ …
+└── database/ …
+```
+
+To add a new shape (e.g. `streaming`), create `scripts/templates/source/streaming/{source.py.j2,config.yaml.j2}` and add `"streaming"` to `SHAPES` in `scripts/new_source.py`. Templates receive these Jinja context vars: `name`, `name_upper`, `name_title`.
+
+## Related
+
+- [`docs/source-layout.md`](source-layout.md) — the layout convention the generator produces
+- [`docs/staging.md`](staging.md) — staging-model codegen from Soda contracts
+- [`docs/template.md`](template.md) — one-command fork rebrand (separate from per-source scaffolding)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,7 @@ nav:
   - Contracts: contracts.md
   - Staging codegen: staging.md
   - Source layout: source-layout.md
+  - New source generator: new-source.md
   - Forking the scaffold: template.md
   - CI routing: ci.md
   - Configuration: configuration.md

--- a/scripts/new_source.py
+++ b/scripts/new_source.py
@@ -1,0 +1,245 @@
+"""Scaffold a new dlt source following `docs/source-layout.md`.
+
+Creates the full per-source tree (source package, model dirs with `.gitkeep`,
+Soda contract dirs, Dagster domain stub), wires the new domain module into
+`definitions.py`, and optionally appends an API-key line to `.env.example`.
+The output passes `scripts/check_source_layout.py` on first commit because
+the generated `source.py` carries a `scaffold-lint: skip=scaffolded` marker.
+
+Usage:
+    python scripts/new_source.py <name>
+    python scripts/new_source.py <name> --shape file
+    python scripts/new_source.py <name> --shape database --force
+    python scripts/new_source.py <name> --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
+ROOT = Path(__file__).resolve().parent.parent
+TEMPLATES_DIR = Path(__file__).resolve().parent / "templates" / "source"
+SHAPES = ("rest", "file", "database")
+
+SOURCES_PKG_DIR = ROOT / "packages/databox-sources/databox_sources"
+MODELS_DIR = ROOT / "transforms/main/models"
+CONTRACTS_DIR = ROOT / "soda/contracts"
+DOMAINS_DIR = ROOT / "packages/databox/databox/orchestration/domains"
+DEFINITIONS_PATH = ROOT / "packages/databox/databox/orchestration/definitions.py"
+ENV_EXAMPLE_PATH = ROOT / ".env.example"
+
+NAME_PATTERN = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+@dataclass
+class PlannedFile:
+    path: Path
+    content: str
+
+
+def validate_name(name: str) -> None:
+    if not NAME_PATTERN.match(name):
+        raise ValueError(
+            f"invalid source name {name!r}: must be lowercase, start with a letter, "
+            "and contain only [a-z0-9_]"
+        )
+    reserved = {"analytics", "_shared", "base", "registry"}
+    if name in reserved:
+        raise ValueError(f"source name {name!r} is reserved; pick another")
+
+
+def render(shape: str, name: str) -> dict[Path, str]:
+    """Return the planned file tree for a new source: {relative_path: content}."""
+    env = Environment(
+        loader=FileSystemLoader([str(TEMPLATES_DIR / "common"), str(TEMPLATES_DIR / shape)]),
+        keep_trailing_newline=True,
+        undefined=StrictUndefined,
+        autoescape=False,
+    )
+    ctx = {"name": name, "name_upper": name.upper(), "name_title": name.title()}
+
+    files: dict[Path, str] = {
+        SOURCES_PKG_DIR / name / "__init__.py": env.get_template("__init__.py.j2").render(**ctx),
+        SOURCES_PKG_DIR / name / "source.py": env.get_template("source.py.j2").render(**ctx),
+        SOURCES_PKG_DIR / name / "config.yaml": env.get_template("config.yaml.j2").render(**ctx),
+        DOMAINS_DIR / f"{name}.py": env.get_template("domain.py.j2").render(**ctx),
+        MODELS_DIR / name / "staging" / ".gitkeep": "",
+        MODELS_DIR / name / "marts" / ".gitkeep": "",
+        CONTRACTS_DIR / f"{name}_staging" / ".gitkeep": "",
+        CONTRACTS_DIR / name / ".gitkeep": "",
+    }
+    return files
+
+
+def check_collision(files: dict[Path, str], force: bool) -> list[Path]:
+    """Return existing paths. If `force` is False and any exist, caller should abort."""
+    existing = [p for p in files if p.exists()]
+    if existing and not force:
+        return existing
+    return []
+
+
+def write_files(files: dict[Path, str]) -> None:
+    for path, content in files.items():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+
+
+def wire_definitions(name: str, path: Path | None = None) -> bool:
+    """Add `name` to the domains import line and to the three splat-wiring
+    points in `definitions.py`. Idempotent — returns True if anything changed.
+    """
+    if path is None:
+        path = DEFINITIONS_PATH
+    text = path.read_text()
+    changed = False
+
+    # 1. Import line — alphabetical insertion.
+    import_re = re.compile(r"^(from databox\.orchestration\.domains import )(.+)$", re.MULTILINE)
+    m = import_re.search(text)
+    if m is None:
+        raise RuntimeError("could not locate domains import in definitions.py")
+    current = sorted({n.strip() for n in m.group(2).split(",") if n.strip()})
+    if name not in current:
+        merged = sorted([*current, name])
+        new_import = f"{m.group(1)}{', '.join(merged)}"
+        text = import_re.sub(new_import, text, count=1)
+        changed = True
+
+    # 2. Splat anchors — insert before the analytics entry in each list.
+    splat_targets = [
+        (
+            f"        *{name}.sqlmesh_asset_keys,",
+            "        *analytics.sqlmesh_asset_keys,",
+        ),
+        (
+            f"        *{name}.asset_checks,",
+            "        *analytics.asset_checks,",
+        ),
+    ]
+    for new_line, anchor in splat_targets:
+        if new_line in text:
+            continue
+        if anchor not in text:
+            raise RuntimeError(f"could not find anchor {anchor!r} in definitions.py")
+        text = text.replace(anchor, f"{new_line}\n{anchor}", 1)
+        changed = True
+
+    # 3. dlt_asset_keys splat — insert just before the first sqlmesh_asset_keys line.
+    dlt_line = f"        *{name}.dlt_asset_keys,"
+    if dlt_line not in text:
+        anchor = "        *ebird.sqlmesh_asset_keys,"
+        if anchor not in text:
+            raise RuntimeError("could not find ebird.sqlmesh_asset_keys anchor")
+        text = text.replace(anchor, f"{dlt_line}\n{anchor}", 1)
+        changed = True
+
+    if changed:
+        path.write_text(text)
+    return changed
+
+
+def ensure_env_stub(name: str, path: Path | None = None) -> bool:
+    """Append an `API_KEY_<NAME>=` line to `.env.example` if missing.
+
+    Returns True if the file was modified (or would be, in dry-run)."""
+    if path is None:
+        path = ENV_EXAMPLE_PATH
+    key = f"API_KEY_{name.upper()}="
+    if not path.exists():
+        return False
+    text = path.read_text()
+    if key in text:
+        return False
+    suffix = "\n" if text.endswith("\n") else "\n\n"
+    path.write_text(text + f"{suffix}{key}\n")
+    return True
+
+
+def print_next_steps(name: str) -> None:
+    title = name.title()
+    print(f"\nScaffolded source '{name}'. Next steps:\n")
+    print(
+        f"  1. Fill in `@dlt.resource`s in "
+        f"packages/databox-sources/databox_sources/{name}/source.py,"
+        f" then remove the `# scaffold-lint: skip=scaffolded` marker."
+    )
+    print(
+        f"  2. Add staging SQL under transforms/main/models/{name}/staging/"
+        f" (at least one `stg_*.sql`)."
+    )
+    print(
+        f"  3. Add a Soda contract under soda/contracts/{name}_staging/ for each staging table,"
+        f" then mart contracts under soda/contracts/{name}/."
+    )
+    print(
+        f"  4. Wire the real assets in packages/databox/databox/orchestration/domains/{name}.py"
+        f" and `{title.lower()}.daily_pipeline` / `.schedule` into definitions.py."
+    )
+    print("  5. Run `task check:layout` and `task ci` to verify.\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0] if __doc__ else "")
+    p.add_argument("name", help="source name (lowercase, snake_case)")
+    p.add_argument(
+        "--shape",
+        choices=SHAPES,
+        default="rest",
+        help="which template set to use (default: rest)",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print the planned file tree without writing",
+    )
+    p.add_argument(
+        "--force",
+        action="store_true",
+        help="overwrite files that already exist on disk",
+    )
+    args = p.parse_args(argv)
+
+    try:
+        validate_name(args.name)
+    except ValueError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 2
+
+    files = render(args.shape, args.name)
+
+    if args.dry_run:
+        print(f"Would create {len(files)} file(s) for source '{args.name}' (shape={args.shape}):")
+        for path in sorted(files):
+            marker = " (exists)" if path.exists() else ""
+            print(f"  {path.relative_to(ROOT)}{marker}")
+        print("\n(no files written — pass without --dry-run to scaffold)")
+        return 0
+
+    collisions = check_collision(files, force=args.force)
+    if collisions:
+        print(
+            f"error: {len(collisions)} file(s) already exist; pass --force to overwrite:",
+            file=sys.stderr,
+        )
+        for path in collisions:
+            print(f"  {path.relative_to(ROOT)}", file=sys.stderr)
+        return 1
+
+    write_files(files)
+    wire_definitions(args.name)
+    if args.shape == "rest":
+        ensure_env_stub(args.name)
+
+    print_next_steps(args.name)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/templates/source/common/__init__.py.j2
+++ b/scripts/templates/source/common/__init__.py.j2
@@ -1,0 +1,1 @@
+"""{{ name_title }} source package."""

--- a/scripts/templates/source/common/domain.py.j2
+++ b/scripts/templates/source/common/domain.py.j2
@@ -1,0 +1,25 @@
+"""{{ name_title }} domain — scaffolded stub.
+
+This file is wired into `definitions.py` with empty asset lists so Dagster
+loads clean on day one. Fill in as you add resources:
+
+  1. In `databox_sources/{{ name }}/source.py`, define `@dlt.resource`s and a
+     `@dlt.source` that yields them.
+  2. Build `{{ name }}_dlt_assets` here via `@dlt_assets(...)` (see usgs.py
+     for the canonical shape), then populate `dlt_asset_keys`.
+  3. Add SQLMesh models under `transforms/main/models/{{ name }}/`, enumerate
+     their keys in `sqlmesh_asset_keys`.
+  4. Add Soda contracts under `soda/contracts/{{ name }}{,_staging}/`,
+     register them in `asset_checks`.
+  5. Define `daily_pipeline`, `schedule`, and wire them into `definitions.py`.
+
+Until then, the empty splats below are no-ops — Dagster sees the module.
+"""
+
+from __future__ import annotations
+
+import dagster as dg
+
+dlt_asset_keys: list[dg.AssetKey] = []
+sqlmesh_asset_keys: list[dg.AssetKey] = []
+asset_checks: list[dg.AssetChecksDefinition] = []

--- a/scripts/templates/source/database/config.yaml.j2
+++ b/scripts/templates/source/database/config.yaml.j2
@@ -1,0 +1,8 @@
+source_module: "databox_sources.{{ name }}.source"
+description: "TODO: describe the {{ name_title }} database source"
+schedule:
+  cron: "0 6 * * *"
+  enabled: false
+params:
+  dsn_env: "DATABASE_URL_{{ name_upper }}"
+quality_rules: []

--- a/scripts/templates/source/database/source.py.j2
+++ b/scripts/templates/source/database/source.py.j2
@@ -1,0 +1,37 @@
+# scaffold-lint: skip=scaffolded
+"""{{ name_title }} SQL database source pipeline using dlt.
+
+TODO: describe the upstream database — engine, read model, incremental key.
+
+The `scaffold-lint: skip=scaffolded` marker tells the layout linter to
+tolerate missing staging/mart/contract files while this source is being
+built. Remove it once the full layout is in place.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from typing import Any
+
+import dlt
+
+# TODO: prefer `dlt.sources.sql_database` when the upstream is a full DB —
+# this stub shows the raw-query shape for simple cases.
+
+
+@dlt.resource(name="{{ name }}_records", write_disposition="append", primary_key="id")
+def {{ name }}_records() -> Iterator[dict[str, Any]]:
+    """TODO: connect, query, yield rows as dicts."""
+    dsn = os.environ.get("DATABASE_URL_{{ name_upper }}")
+    if not dsn:
+        raise RuntimeError(
+            "DATABASE_URL_{{ name_upper }} not set — add it to .env (see .env.example)."
+        )
+    # TODO: use sqlalchemy / psycopg / duckdb / etc. and real incremental logic.
+    yield {"id": "example", "dsn_length": len(dsn)}
+
+
+@dlt.source(name="{{ name }}_source")
+def {{ name }}_source() -> Any:
+    yield {{ name }}_records

--- a/scripts/templates/source/file/config.yaml.j2
+++ b/scripts/templates/source/file/config.yaml.j2
@@ -1,0 +1,8 @@
+source_module: "databox_sources.{{ name }}.source"
+description: "TODO: describe the {{ name_title }} file source"
+schedule:
+  cron: "0 6 * * *"
+  enabled: false
+params:
+  source_path: "/path/to/{{ name }}/data"
+quality_rules: []

--- a/scripts/templates/source/file/source.py.j2
+++ b/scripts/templates/source/file/source.py.j2
@@ -1,0 +1,36 @@
+# scaffold-lint: skip=scaffolded
+"""{{ name_title }} filesystem / S3 source pipeline using dlt.
+
+TODO: describe the source files — location, format (CSV / Parquet / JSON),
+partitioning, and cadence.
+
+The `scaffold-lint: skip=scaffolded` marker tells the layout linter to
+tolerate missing staging/mart/contract files. Remove it once the full layout
+is in place.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import dlt
+
+# TODO: for S3 / GCS / Azure, use dlt.sources.filesystem instead of local Path.
+SOURCE_PATH = Path("/path/to/{{ name }}/data")
+
+
+@dlt.resource(name="{{ name }}_records", write_disposition="append", primary_key="id")
+def {{ name }}_records() -> Iterator[dict[str, Any]]:
+    """TODO: iterate files, parse rows, yield dicts."""
+    if not SOURCE_PATH.exists():
+        raise RuntimeError(f"source path does not exist: {SOURCE_PATH}")
+    for path in sorted(SOURCE_PATH.glob("*.csv")):
+        # TODO: replace with real parser (csv / pyarrow / json / etc.)
+        yield {"id": path.stem, "path": str(path)}
+
+
+@dlt.source(name="{{ name }}_source")
+def {{ name }}_source() -> Any:
+    yield {{ name }}_records

--- a/scripts/templates/source/rest/config.yaml.j2
+++ b/scripts/templates/source/rest/config.yaml.j2
@@ -1,0 +1,7 @@
+source_module: "databox_sources.{{ name }}.source"
+description: "TODO: describe the {{ name_title }} data source"
+schedule:
+  cron: "0 6 * * *"
+  enabled: false
+params: {}
+quality_rules: []

--- a/scripts/templates/source/rest/source.py.j2
+++ b/scripts/templates/source/rest/source.py.j2
@@ -1,0 +1,51 @@
+# scaffold-lint: skip=scaffolded
+"""{{ name_title }} REST API source pipeline using dlt.
+
+TODO: describe the upstream API, auth model, rate limits, pagination.
+
+The `scaffold-lint: skip=scaffolded` marker above tells
+`scripts/check_source_layout.py` to tolerate the missing staging/mart/contract
+files while this source is being built. Remove the marker once the layout is
+complete.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from typing import Any
+
+import dlt
+from dlt.sources.helpers import requests as dlt_requests
+
+{{ name_upper }}_BASE = "https://api.example.com/v1"  # TODO: set real base URL
+
+
+@dlt.resource(name="{{ name }}_records", write_disposition="append", primary_key="id")
+def {{ name }}_records() -> Iterator[dict[str, Any]]:
+    """TODO: replace with real resource logic.
+
+    Example flow:
+      1. Read API token from env var (`API_KEY_{{ name_upper }}`).
+      2. Build request URL + params.
+      3. Page through results, yield dicts.
+    """
+    token = os.environ.get("API_KEY_{{ name_upper }}")
+    if not token:
+        raise RuntimeError(
+            "API_KEY_{{ name_upper }} not set — add it to .env (see .env.example)."
+        )
+    # TODO: implement real pagination loop
+    response = dlt_requests.get(
+        f"{{ '{' }}{{ name_upper }}_BASE{{ '}' }}/records",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    response.raise_for_status()
+    for record in response.json().get("items", []):
+        yield record
+
+
+@dlt.source(name="{{ name }}_source")
+def {{ name }}_source() -> Any:
+    """TODO: yield each @dlt.resource defined in this module."""
+    yield {{ name }}_records

--- a/tests/test_new_source.py
+++ b/tests/test_new_source.py
@@ -1,0 +1,202 @@
+"""Unit tests for scripts/new_source.py.
+
+Exercises the generator against a synthetic repo root in tmp_path. Uses
+monkeypatch to rebind the module's path constants so the real check_source_layout
+linter can verify the scaffolded tree.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+NEW_SOURCE_SCRIPT = Path(__file__).parent.parent / "scripts" / "new_source.py"
+LAYOUT_SCRIPT = Path(__file__).parent.parent / "scripts" / "check_source_layout.py"
+
+
+def _load(name: str, path: Path):
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _scaffold_repo(tmp_path: Path) -> Path:
+    """Build a minimal repo skeleton the generator can write into."""
+    (tmp_path / "packages/databox-sources/databox_sources").mkdir(parents=True)
+    (tmp_path / "packages/databox-sources/databox_sources/__init__.py").write_text("")
+    (tmp_path / "transforms/main/models").mkdir(parents=True)
+    (tmp_path / "soda/contracts").mkdir(parents=True)
+    (tmp_path / "packages/databox/databox/orchestration/domains").mkdir(parents=True)
+    (tmp_path / "packages/databox/databox/orchestration/domains/__init__.py").write_text("")
+
+    defs_path = tmp_path / "packages/databox/databox/orchestration/definitions.py"
+    defs_path.write_text(
+        '''"""Dagster definitions — stub for tests."""
+
+from __future__ import annotations
+
+import dagster as dg
+
+from databox.orchestration.domains import analytics, ebird, noaa, usgs
+
+all_pipelines = dg.define_asset_job(
+    name="all_pipelines",
+    selection=dg.AssetSelection.assets(
+        *ebird.dlt_asset_keys,
+        *noaa.dlt_asset_keys,
+        *usgs.dlt_asset_keys,
+        *ebird.sqlmesh_asset_keys,
+        *noaa.sqlmesh_asset_keys,
+        *usgs.sqlmesh_asset_keys,
+        *analytics.sqlmesh_asset_keys,
+    ),
+)
+
+defs = dg.Definitions(
+    asset_checks=[
+        *ebird.asset_checks,
+        *noaa.asset_checks,
+        *usgs.asset_checks,
+        *analytics.asset_checks,
+    ],
+)
+'''
+    )
+
+    env_example = tmp_path / ".env.example"
+    env_example.write_text("EBIRD_API_TOKEN=\n")
+    return tmp_path
+
+
+def _rebind(gen_module, layout_module, root: Path) -> None:
+    gen_module.ROOT = root
+    gen_module.SOURCES_PKG_DIR = root / "packages/databox-sources/databox_sources"
+    gen_module.MODELS_DIR = root / "transforms/main/models"
+    gen_module.CONTRACTS_DIR = root / "soda/contracts"
+    gen_module.DOMAINS_DIR = root / "packages/databox/databox/orchestration/domains"
+    gen_module.DEFINITIONS_PATH = root / "packages/databox/databox/orchestration/definitions.py"
+    gen_module.ENV_EXAMPLE_PATH = root / ".env.example"
+
+    layout_module.SOURCES_DIR = gen_module.SOURCES_PKG_DIR
+    layout_module.MODELS_DIR = gen_module.MODELS_DIR
+    layout_module.CONTRACTS_DIR = gen_module.CONTRACTS_DIR
+    layout_module.DOMAINS_DIR = gen_module.DOMAINS_DIR
+
+
+@pytest.fixture
+def env(tmp_path: Path):
+    gen = _load("new_source", NEW_SOURCE_SCRIPT)
+    layout = _load("check_source_layout", LAYOUT_SCRIPT)
+    root = _scaffold_repo(tmp_path)
+    _rebind(gen, layout, root)
+    return gen, layout, root
+
+
+def test_validate_name_rejects_uppercase() -> None:
+    gen = _load("new_source", NEW_SOURCE_SCRIPT)
+    with pytest.raises(ValueError):
+        gen.validate_name("Bad")
+
+
+def test_validate_name_rejects_reserved() -> None:
+    gen = _load("new_source", NEW_SOURCE_SCRIPT)
+    with pytest.raises(ValueError):
+        gen.validate_name("analytics")
+
+
+@pytest.mark.parametrize("shape", ["rest", "file", "database"])
+def test_generated_tree_passes_layout_lint(env, shape: str) -> None:
+    gen, layout, _ = env
+    assert gen.main(["demo", "--shape", shape]) == 0
+    report = layout.check_source("demo")
+    assert report.skipped
+    assert report.skip_reason == "scaffolded"
+    assert report.ok
+
+
+def test_definitions_wired_idempotently(env) -> None:
+    gen, _, root = env
+    assert gen.main(["demo"]) == 0
+    defs = (root / "packages/databox/databox/orchestration/definitions.py").read_text()
+    assert "import analytics, demo, ebird" in defs
+    assert "*demo.dlt_asset_keys," in defs
+    assert "*demo.sqlmesh_asset_keys," in defs
+    assert "*demo.asset_checks," in defs
+
+    # Second call with --force regenerates; wiring stays singular.
+    assert gen.main(["demo", "--force"]) == 0
+    defs2 = (root / "packages/databox/databox/orchestration/definitions.py").read_text()
+    assert defs2.count("*demo.dlt_asset_keys,") == 1
+    assert defs2.count("*demo.sqlmesh_asset_keys,") == 1
+    assert defs2.count("*demo.asset_checks,") == 1
+
+
+def test_collision_without_force_refuses(env) -> None:
+    gen, _, _ = env
+    assert gen.main(["demo"]) == 0
+    # Second run without --force must fail.
+    assert gen.main(["demo"]) == 1
+
+
+def test_dry_run_writes_nothing(env, capsys) -> None:
+    gen, _, root = env
+    assert gen.main(["demo", "--dry-run"]) == 0
+    # No source directory should have been created.
+    assert not (root / "packages/databox-sources/databox_sources/demo").exists()
+    out = capsys.readouterr().out
+    assert "Would create" in out
+    assert "no files written" in out
+
+
+def test_rest_shape_adds_env_stub(env) -> None:
+    gen, _, root = env
+    assert gen.main(["demo", "--shape", "rest"]) == 0
+    env_text = (root / ".env.example").read_text()
+    assert "API_KEY_DEMO=" in env_text
+
+
+def test_file_shape_does_not_touch_env_example(env) -> None:
+    gen, _, root = env
+    assert gen.main(["demo", "--shape", "file"]) == 0
+    env_text = (root / ".env.example").read_text()
+    assert "API_KEY_DEMO=" not in env_text
+
+
+def test_generated_source_py_has_skip_marker(env) -> None:
+    gen, _, root = env
+    assert gen.main(["demo"]) == 0
+    src_py = (
+        (root / "packages/databox-sources/databox_sources/demo/source.py")
+        .read_text()
+        .splitlines()[:10]
+    )
+    assert any("scaffold-lint: skip=scaffolded" in line for line in src_py)
+
+
+def test_gitkeep_files_present(env) -> None:
+    gen, _, root = env
+    assert gen.main(["demo"]) == 0
+    for relpath in [
+        "transforms/main/models/demo/staging/.gitkeep",
+        "transforms/main/models/demo/marts/.gitkeep",
+        "soda/contracts/demo_staging/.gitkeep",
+        "soda/contracts/demo/.gitkeep",
+    ]:
+        assert (root / relpath).exists(), relpath
+
+
+def test_domain_stub_is_valid_python(env) -> None:
+    gen, _, root = env
+    assert gen.main(["demo"]) == 0
+    domain = (root / "packages/databox/databox/orchestration/domains/demo.py").read_text()
+    compile(domain, "demo.py", "exec")
+    assert "dlt_asset_keys: list" in domain
+    assert "asset_checks: list" in domain


### PR DESCRIPTION
## Summary
- `scripts/new_source.py` (wrapped by `task new-source`) scaffolds every file required by `docs/source-layout.md` in one command.
- Jinja2 templates under `scripts/templates/source/` split into `common/` (shared: `__init__.py`, `domain.py`) plus per-shape dirs (`rest/`, `file/`, `database/`) for `source.py` + `config.yaml`.
- Generated `source.py` carries `# scaffold-lint: skip=scaffolded` → layout lint reports `~ <name> (skipped: scaffolded)` instead of failing. Author removes the marker once staging/mart/contract files are in place.
- Wires the new domain into `packages/databox/databox/orchestration/definitions.py`:
  - alphabetical insertion into the domains import line
  - splats `*<name>.dlt_asset_keys`, `*<name>.sqlmesh_asset_keys`, `*<name>.asset_checks` into the right lists
  - fully idempotent (second `--force` run doesn't duplicate wiring)
- `--shape rest` appends `API_KEY_<NAME>=` to `.env.example`.
- `--dry-run` prints the planned tree, writes nothing. `--force` overwrites collisions. Default refuses.
- Prints a 5-step next-steps checklist on success.
- `docs/new-source.md` is a full walkthrough from generator to first-green Soda contract.

## Tests
- 13 new tests in `tests/test_new_source.py` — validates name rules, layout-lint pass per shape, definitions.py wiring idempotency, collision handling, dry-run, env stub, skip-marker presence, gitkeep files, domain stub compilability.
- All 86 tests pass locally.

## Verified live
- `uv run python scripts/new_source.py scaffoldtest` → scaffold built, layout lint passed with scaffolded-skip marker, mypy clean. (Cleaned up before commit.)

## Test plan
- [ ] CI passes full matrix (cross-cutting change)
- [ ] Manual: `task new-source -- demo --shape rest` produces a tree that passes `task check:layout` with `~ demo (skipped: scaffolded)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)