### PR TITLE
feat(envs): dev → verify → prod SQLMesh virtual-env workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,7 +146,7 @@ in `examples/secrets/one_password_source.py`.
 - Use `uv` for all package management
 - dlt state lives in `.dlt_state/` at project root (not in `data/`)
 - Dagster is a core dependency (not optional)
-- After adding new SQLMesh models, run `sqlmesh plan --auto-apply prod` in `transforms/main/` to create prod virtual views before Soda contracts can query them
+- For model edits, use the dev → verify → prod loop: `task plan:dev`, `task verify:dev`, `task plan:prod` (see [docs/environments.md](docs/environments.md)). `sqlmesh plan --auto-apply prod` in `transforms/main/` is the escape hatch for first-time setup and one-off backfills, not the default for iterative changes.
 - Backend switching: set `DATABOX_BACKEND=motherduck` (+ `MOTHERDUCK_TOKEN`) in `.env` to use MotherDuck cloud. Default is `local`. The SQLMesh gateway and Soda datasource derive from `DATABOX_BACKEND` — no separate flag.
 - `databox.config.settings` is the single source of truth for runtime config. SQLMesh reads it via `transforms/main/config.py`; Dagster reads it via the `settings` singleton; Soda datasource YAML is rendered from `settings.soda_datasource_yaml`.
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,11 @@ task full-refresh
 # Or interactive: Dagster UI at localhost:3000
 task dagster:dev
 
+# Edit a model? Propose in dev, verify, promote to prod
+task plan:dev      # materialize into ebird__dev, noaa__dev, ...
+task verify:dev    # Soda contracts run against __dev schemas
+task plan:prod     # promote verified changes — see docs/environments.md
+
 # Launch the Streamlit data explorer
 task streamlit
 ```

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -67,6 +67,33 @@ tasks:
     cmds:
       - python scripts/new_source.py {{.CLI_ARGS}}
 
+  plan:dev:
+    desc: "SQLMesh plan against the dev virtual env (interactive)"
+    deps: [install]
+    dir: transforms/main
+    cmds:
+      - "../../{{.VENV_DIR}}/bin/sqlmesh plan dev {{.CLI_ARGS}}"
+
+  plan:prod:
+    desc: "SQLMesh plan against prod — fails if prod is ahead of dev"
+    deps: [install]
+    dir: transforms/main
+    cmds:
+      - "../../{{.VENV_DIR}}/bin/sqlmesh plan prod {{.CLI_ARGS}}"
+
+  promote:
+    desc: "Promote dev → prod (auto-apply; assumes dev already verified)"
+    deps: [install]
+    dir: transforms/main
+    cmds:
+      - "../../{{.VENV_DIR}}/bin/sqlmesh plan prod --auto-apply {{.CLI_ARGS}}"
+
+  verify:dev:
+    desc: "Run every Soda contract against the __dev schemas (see docs/environments.md)"
+    deps: [install]
+    cmds:
+      - "{{.VENV_DIR}}/bin/python scripts/verify_dev.py"
+
   full-refresh:
     desc: "Run every dlt source + SQLMesh + every Soda check through Dagster"
     deps: [install]

--- a/docs/environments.md
+++ b/docs/environments.md
@@ -1,0 +1,92 @@
+# SQLMesh environments
+
+Databox uses SQLMesh virtual environments to separate **proposed** changes
+from **accepted** production state. One DuckDB file (or one MotherDuck
+account) holds both — environments are metadata, not separate databases.
+
+## The loop
+
+```
+┌────────────┐    plan dev     ┌────────────┐  verify  ┌─────────────┐  plan prod  ┌────────────┐
+│ model edit ├────────────────▶│    dev     ├─────────▶│ dev Soda OK ├────────────▶│    prod    │
+└────────────┘                 └────────────┘          └─────────────┘             └────────────┘
+```
+
+1. Edit a model in `transforms/main/models/`.
+2. `task plan:dev` — SQLMesh materializes the change into the `dev` virtual
+   env. Schemas get `__dev` suffix: `ebird.fct_daily_bird_observations`
+   becomes `ebird__dev.fct_daily_bird_observations`.
+3. `task verify:dev` — Soda contracts run against the `__dev` schemas.
+   Sample queries against `ebird__dev.*` confirm the change looks right.
+4. `task plan:prod` — SQLMesh promotes the dev changes to `prod`. Because
+   the tables already exist (they were materialized for dev), promotion is
+   a metadata-only switch — near-instant, no recompute.
+
+## Why this matters
+
+Without virtual envs, every model edit directly mutates prod. A broken
+change is only caught after downstream consumers see it. With the loop:
+
+- dev is the quarantine. Break it freely.
+- Soda contracts can fail on dev without blocking prod.
+- Promotion is cheap — no recompute on the prod side.
+- Rollback is a `sqlmesh plan prod --restore-from <previous-plan-id>` away.
+
+## Task targets
+
+| Task | What it runs |
+|---|---|
+| `task plan:dev` | `sqlmesh plan dev` — interactive, prompts for model changes |
+| `task verify:dev` | `scripts/verify_dev.py` — runs every Soda contract against the `__dev` schemas |
+| `task plan:prod` | `sqlmesh plan prod` — interactive; fails if prod is ahead of dev |
+| `task promote` | `sqlmesh plan prod --auto-apply` — shorthand when the only delta is a verified dev→prod promotion |
+
+All four target `transforms/main/`. They inherit the `DATABOX_BACKEND`
+setting, so `task plan:dev` works identically on local DuckDB and
+MotherDuck.
+
+## Per-backend notes
+
+**Local DuckDB.** Virtual envs live in the same file. `__dev` schemas
+share buffer pool with `prod` schemas — dev queries are as fast as prod.
+
+**MotherDuck.** Same story. Virtual envs are a SQLMesh construct, not a
+DuckDB feature; the implementation is identical across backends. Cost
+implication: dev materializations do consume MotherDuck storage until
+`sqlmesh janitor` runs (default: 7-day TTL on dev snapshots).
+
+## Soda contracts and schema suffixes
+
+Every Soda contract under `soda/contracts/` hard-codes a dataset path like
+`databox/ebird/fct_daily_bird_observations`. `scripts/verify_dev.py`
+rewrites that to `databox/ebird__dev/fct_daily_bird_observations` in
+memory before handing the YAML to Soda. The committed contract files are
+never edited.
+
+If you add a new source, its contracts automatically pick up the rewrite —
+the script walks every file under `soda/contracts/` and applies a regex.
+
+## Schema-contract gate vs SQLMesh envs
+
+The schema-contract gate (`scripts/schema_gate.py`) operates on Soda
+contract **files** in git — it does not run SQLMesh. It catches breaking
+column changes before `plan dev` ever runs. The two checks are
+complementary:
+
+- **schema-contract gate** — did someone change a contract in a way that
+  would break downstream consumers? (static, PR-time)
+- **`task verify:dev`** — does the dev materialization satisfy every
+  contract check? (runtime, post-plan)
+
+## Staging environment?
+
+A `staging` env between `dev` and `prod` would make sense for a team with
+multiple developers or a formal release cadence. For a single-operator
+scaffold, it adds friction without payoff. The dev → verify → prod loop
+is enough.
+
+## Escape hatches
+
+`sqlmesh plan --auto-apply prod` from the `transforms/main/` directory
+still works and remains useful for one-off backfills or first-time
+setup. Treat it as the exception, not the default.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,6 +68,7 @@ nav:
   - CI routing: ci.md
   - Configuration: configuration.md
   - Secrets: secrets.md
+  - Environments: environments.md
   - Commands: commands.md
   - Incremental loading: incremental-loading.md
   - Architecture decisions:

--- a/scripts/verify_dev.py
+++ b/scripts/verify_dev.py
@@ -1,0 +1,75 @@
+"""Run every Soda contract against the SQLMesh `__dev` virtual environment.
+
+Soda contracts hard-code dataset paths like `databox/ebird/fct_x`. SQLMesh's
+dev env materializes the same table at `ebird__dev.fct_x`. This script
+rewrites `databox/<schema>/<table>` to `databox/<schema>__dev/<table>` in
+each contract YAML (in memory, committed files untouched) and pipes the
+rewritten contract into Soda's ContractVerificationSession.
+
+Exit: 0 if every contract passes, 1 on any failure, 2 on invocation error.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+from databox.config.settings import settings
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+CONTRACTS_DIR = PROJECT_ROOT / "soda" / "contracts"
+
+# Matches `dataset: <db>/<schema>/<table>` (first-line or indented). Captures
+# the schema so we can append `__dev`. Excludes already-suffixed datasets.
+DATASET_RE = re.compile(
+    r"^(\s*dataset:\s*[^/\s]+/)([^/\s_]+(?:_[^/\s_]+)*?)(/[^/\s]+\s*)$",
+    re.MULTILINE,
+)
+
+
+def rewrite_for_dev(contract_yaml: str) -> str:
+    def _sub(match: re.Match[str]) -> str:
+        prefix, schema, tail = match.group(1), match.group(2), match.group(3)
+        if schema.endswith("__dev"):
+            return match.group(0)
+        return f"{prefix}{schema}__dev{tail}"
+
+    return DATASET_RE.sub(_sub, contract_yaml)
+
+
+def main() -> int:
+    from soda_core.common.yaml import ContractYamlSource, DataSourceYamlSource
+    from soda_core.contracts.contract_verification import ContractVerificationSession
+
+    contracts = sorted(CONTRACTS_DIR.rglob("*.yaml")) + sorted(CONTRACTS_DIR.rglob("*.yml"))
+    if not contracts:
+        print("no Soda contracts found", file=sys.stderr)
+        return 2
+
+    datasource_yaml = settings.soda_datasource_yaml
+    failures: list[tuple[Path, str]] = []
+
+    for contract in contracts:
+        original = contract.read_text()
+        rewritten = rewrite_for_dev(original)
+        result = ContractVerificationSession.execute(
+            contract_yaml_sources=[ContractYamlSource.from_str(rewritten)],
+            data_source_yaml_sources=[DataSourceYamlSource.from_str(datasource_yaml)],
+        )
+        if result.is_failed:
+            failures.append((contract, result.get_errors_str()))
+            print(f"FAIL {contract.relative_to(PROJECT_ROOT)}")
+        else:
+            print(f"ok   {contract.relative_to(PROJECT_ROOT)}")
+
+    if failures:
+        print(f"\n{len(failures)} contract(s) failed against __dev schema:", file=sys.stderr)
+        for path, errors in failures:
+            print(f"\n--- {path.relative_to(PROJECT_ROOT)} ---\n{errors}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_verify_dev.py
+++ b/tests/test_verify_dev.py
@@ -1,0 +1,36 @@
+"""Smoke tests for scripts/verify_dev.py contract-rewriter."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "verify_dev.py"
+spec = importlib.util.spec_from_file_location("verify_dev", SCRIPT)
+assert spec and spec.loader
+verify_dev = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(verify_dev)
+
+
+def test_rewrites_bare_schema() -> None:
+    src = "dataset: databox/ebird/fct_daily_bird_observations\n"
+    assert "databox/ebird__dev/fct_daily_bird_observations" in verify_dev.rewrite_for_dev(src)
+
+
+def test_rewrites_staging_suffix_schema() -> None:
+    src = "dataset: databox/ebird_staging/stg_ebird_observations\n"
+    out = verify_dev.rewrite_for_dev(src)
+    assert "databox/ebird_staging__dev/stg_ebird_observations" in out
+
+
+def test_leaves_already_dev_alone() -> None:
+    src = "dataset: databox/ebird__dev/fct_x\n"
+    assert verify_dev.rewrite_for_dev(src) == src
+
+
+def test_preserves_surrounding_yaml() -> None:
+    src = "dataset: databox/analytics/platform_health\ncolumns:\n  - name: region_code\n"
+    out = verify_dev.rewrite_for_dev(src)
+    assert "databox/analytics__dev/platform_health" in out
+    assert "columns:" in out
+    assert "region_code" in out


### PR DESCRIPTION
## Summary
- `docs/environments.md` — full walkthrough of the dev → verify → prod loop, `__dev` schema suffix, Soda contract handling, per-backend notes (local DuckDB + MotherDuck), staging-env tradeoff, escape hatches
- `scripts/verify_dev.py` — rewrites `databox/<schema>/<table>` to `databox/<schema>__dev/<table>` in contract YAML at runtime (committed contracts untouched) and runs Soda's `ContractVerificationSession` against the dev materialization
- `tests/test_verify_dev.py` — 4 rewriter tests (bare schema, `_staging` suffix, idempotence on already-`__dev`, surrounding YAML preserved)
- `Taskfile`: `plan:dev`, `plan:prod`, `promote`, `verify:dev`
- README Quickstart shows the loop for a forker's first model edit
- CLAUDE.md reframes `sqlmesh plan --auto-apply prod` as an escape hatch
- mkdocs nav adds Environments page

Closes `ticket:dev-prod-envs`. The schema-contract gate (`scripts/schema_gate.py`) is file-diff-based and unchanged — it complements the dev-env flow; `docs/environments.md` explicitly distinguishes the two.

## Test plan
- [x] `ruff check` + `ruff format --check` clean
- [x] `pytest tests/` — 78 passed (4 new rewriter tests)
- [x] `mkdocs build --strict` clean
- [x] `task --list-all` shows all four new targets
- [x] `check_secrets.py` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)