### PR TITLE
feat(freshness): per-mart SLAs + violation sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,10 @@ Dagster is the one entrypoint — individual pipeline runs, quality checks,
 schedules, and sensors all happen as assets in the same DAG. See
 [ADR-0005](docs/adr/0005-dagster-as-sole-orchestrator.md).
 
+Per-mart staleness SLAs are declared in each domain module and validated
+by `last_update` asset checks; a sensor emits a structured warning line
+per violation. See [docs/freshness.md](docs/freshness.md).
+
 ## Forking
 
 Databox is designed to be forked. After cloning:

--- a/docs/freshness.md
+++ b/docs/freshness.md
@@ -1,0 +1,84 @@
+# Freshness SLAs
+
+Every mart asset declares a staleness tolerance. If a mart's latest
+materialization is older than its SLA, its freshness check fails and the
+`freshness_violation_sensor` logs a structured warning line one tick later
+(sensor default interval: 300s).
+
+## Declared SLAs
+
+| Asset | Max staleness | Reason |
+|-------|---------------|--------|
+| `sqlmesh/ebird/fct_daily_bird_observations` | 30 hours | Daily ingest at 06:00; 30h gives one day + 6h headroom. |
+| `sqlmesh/ebird/dim_species` | 7 days | Taxonomy refreshes rarely; weekly cadence is fine. |
+| `sqlmesh/ebird/fct_hotspot_species_diversity` | 30 hours | Derived from daily observation feed. |
+| `sqlmesh/noaa/fct_daily_weather` | 48 hours | NOAA GHCND lags ~24h; 48h absorbs common delays. |
+| `sqlmesh/usgs/fct_daily_streamflow` | 30 hours | USGS NWIS is near-real-time; 30h flags true stalls. |
+| `sqlmesh/analytics/fct_species_environment_daily` | 48 hours | Cross-domain mart inherits NOAA's slower cadence. |
+| `sqlmesh/analytics/platform_health` | 2 hours | Self-reporting health view; should be near-live. |
+
+## Two complementary mechanisms
+
+Databox uses both declarative policy **and** runtime validation:
+
+1. **`FreshnessPolicy` (declarative)** — `apply_freshness` tags each
+   source-derived spec with a cron-based expectation so Dagster's UI
+   can signal "overdue" even without runs. Configured in
+   `_factories.py:FRESHNESS_BY_SOURCE`.
+2. **`build_last_update_freshness_checks` (runtime)** — per-asset
+   `AssetCheck` that compares the latest materialization timestamp to
+   a `timedelta`. Wired via `freshness_checks(SLAS)` inside each
+   domain file.
+
+The check is what actually fails and emits an asset-check evaluation
+event; the policy is what tells operators the expected cadence up front.
+
+## Violation sensor
+
+`freshness_violation_sensor` scans `ASSET_CHECK_EVALUATION` events since
+the last tick and logs one warning line per failure:
+
+```
+freshness_violation asset=["sqlmesh","noaa","fct_daily_weather"] check=... timestamp=...
+```
+
+Ships disabled (`DefaultSensorStatus.STOPPED`) so a fresh checkout does
+not spam an operator who has not picked an alert channel. Enable in the
+Dagster UI once you have wired the log line to Slack / Email /
+PagerDuty. The sensor owns the transport — the log is the contract.
+
+### Wiring to an alert channel
+
+Pick one:
+
+- **Slack** — filter Dagster logs where message starts with
+  `freshness_violation`; post into `#data-alerts`.
+- **Email** — same filter via your log-to-email forwarder.
+- **PagerDuty** — only for SLAs short enough to be genuinely urgent
+  (e.g., `platform_health` at 2h). Most forkers will not need this.
+
+## Overriding per fork
+
+Every SLA lives in a per-domain `FRESHNESS_SLAS` dict
+(`packages/databox/databox/orchestration/domains/<source>.py`). Edit the
+`timedelta` or remove the entry to relax / tighten a check; no
+cross-cutting config needed.
+
+To add a new mart:
+
+```python
+FRESHNESS_SLAS: dict[dg.AssetKey, timedelta] = {
+    ...,
+    dg.AssetKey(["sqlmesh", "<schema>", "<table>"]): timedelta(hours=24),
+}
+```
+
+`freshness_checks(FRESHNESS_SLAS)` in `asset_checks` picks it up
+automatically.
+
+## Why not one global SLA
+
+Source cadence varies by orders of magnitude. A global `24h` would
+either false-alarm on NOAA (which legitimately lags) or miss
+`platform_health` stalls (which should fire in minutes). Per-asset
+SLAs keep the signal honest.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ nav:
   - Configuration: configuration.md
   - Secrets: secrets.md
   - Environments: environments.md
+  - Freshness SLAs: freshness.md
   - Commands: commands.md
   - Incremental loading: incremental-loading.md
   - Architecture decisions:

--- a/packages/databox/databox/orchestration/_factories.py
+++ b/packages/databox/databox/orchestration/_factories.py
@@ -138,3 +138,68 @@ def apply_freshness(spec: dg.AssetSpec) -> dg.AssetSpec:
     if src is None:
         return spec
     return dg.apply_freshness_policy(spec, FRESHNESS_BY_SOURCE[src])
+
+
+def freshness_checks(
+    slas: dict[dg.AssetKey, timedelta],
+) -> list[dg.AssetChecksDefinition]:
+    """Build `last_update` freshness checks from an SLA map.
+
+    Each entry declares the maximum tolerable staleness. A check fails when
+    the asset's latest materialization timestamp is older than that window.
+    One check per asset keeps the asset-check panel in Dagster readable.
+    """
+    checks: list[dg.AssetChecksDefinition] = []
+    for key, max_lag in slas.items():
+        checks.extend(
+            dg.build_last_update_freshness_checks(
+                assets=[key],
+                lower_bound_delta=max_lag,
+                severity=dg.AssetCheckSeverity.WARN,
+            )
+        )
+    return checks
+
+
+@dg.sensor(
+    name="freshness_violation_sensor",
+    minimum_interval_seconds=300,
+    default_status=dg.DefaultSensorStatus.STOPPED,
+)
+def freshness_violation_sensor(context: dg.SensorEvaluationContext) -> dg.SensorResult:
+    """Emit a structured log line per asset-check failure since last tick.
+
+    Includes freshness checks (built via `freshness_checks(...)`) and any
+    other asset check that failed. Transports (Slack / Email / PagerDuty)
+    are the forker's choice — wire the log line into your alerting channel
+    of choice. See docs/freshness.md.
+
+    Sensor ships disabled by default (DefaultSensorStatus.STOPPED) so a
+    fresh checkout does not spam a forker who has not yet picked a channel.
+    """
+    cursor = int(context.cursor) if context.cursor else 0
+    records = context.instance.get_event_records(
+        dg.EventRecordsFilter(
+            event_type=dg.DagsterEventType.ASSET_CHECK_EVALUATION,
+            after_cursor=cursor,
+        ),
+        limit=500,
+        ascending=True,
+    )
+
+    latest_cursor = cursor
+    for record in records:
+        latest_cursor = max(latest_cursor, record.storage_id)
+        event = record.event_log_entry.dagster_event
+        if event is None:
+            continue
+        evaluation = event.event_specific_data
+        if evaluation is None or evaluation.passed:  # type: ignore[union-attr]
+            continue
+        context.log.warning(
+            "freshness_violation "
+            f"asset={evaluation.asset_check_key.asset_key.to_user_string()} "  # type: ignore[union-attr]
+            f"check={evaluation.asset_check_key.name} "  # type: ignore[union-attr]
+            f"timestamp={record.event_log_entry.timestamp}"
+        )
+    return dg.SensorResult(cursor=str(latest_cursor))

--- a/packages/databox/databox/orchestration/definitions.py
+++ b/packages/databox/databox/orchestration/definitions.py
@@ -10,7 +10,12 @@ import dagster as dg
 from dagster_dlt import DagsterDltResource
 from dagster_sqlmesh import SQLMeshResource
 
-from databox.orchestration._factories import DataboxConfig, apply_freshness, sqlmesh_project
+from databox.orchestration._factories import (
+    DataboxConfig,
+    apply_freshness,
+    freshness_violation_sensor,
+    sqlmesh_project,
+)
 from databox.orchestration.domains import analytics, ebird, noaa, usgs
 
 all_pipelines = dg.define_asset_job(
@@ -36,6 +41,7 @@ defs = dg.Definitions(
     ],
     jobs=[ebird.daily_pipeline, noaa.daily_pipeline, usgs.daily_pipeline, all_pipelines],
     schedules=[ebird.schedule, noaa.schedule, usgs.schedule],
+    sensors=[freshness_violation_sensor],
     resources={
         "databox_config": DataboxConfig(),
         "dlt": DagsterDltResource(),

--- a/packages/databox/databox/orchestration/domains/analytics.py
+++ b/packages/databox/databox/orchestration/domains/analytics.py
@@ -6,9 +6,11 @@ rebuilt as part of any upstream source run via `all_pipelines`.
 
 from __future__ import annotations
 
+from datetime import timedelta
+
 import dagster as dg
 
-from databox.orchestration._factories import SODA_DIR, soda_check
+from databox.orchestration._factories import SODA_DIR, freshness_checks, soda_check
 
 sqlmesh_asset_keys = [
     dg.AssetKey(["sqlmesh", "analytics", "fct_bird_weather_daily"]),
@@ -16,6 +18,11 @@ sqlmesh_asset_keys = [
     dg.AssetKey(["sqlmesh", "analytics", "fct_species_environment_daily"]),
     dg.AssetKey(["sqlmesh", "analytics", "platform_health"]),
 ]
+
+FRESHNESS_SLAS: dict[dg.AssetKey, timedelta] = {
+    dg.AssetKey(["sqlmesh", "analytics", "fct_species_environment_daily"]): timedelta(hours=48),
+    dg.AssetKey(["sqlmesh", "analytics", "platform_health"]): timedelta(hours=2),
+}
 
 asset_checks: list[dg.AssetChecksDefinition] = [
     soda_check(
@@ -34,4 +41,5 @@ asset_checks: list[dg.AssetChecksDefinition] = [
         dg.AssetKey(["sqlmesh", "analytics", "fct_species_environment_daily"]),
         SODA_DIR / "contracts/analytics/fct_species_environment_daily.yaml",
     ),
+    *freshness_checks(FRESHNESS_SLAS),
 ]

--- a/packages/databox/databox/orchestration/domains/ebird.py
+++ b/packages/databox/databox/orchestration/domains/ebird.py
@@ -1,5 +1,7 @@
 """eBird domain — dlt ingestion + SQLMesh marts + Soda checks."""
 
+from datetime import timedelta
+
 import dagster as dg
 import dlt
 from dagster import AssetExecutionContext
@@ -11,6 +13,7 @@ from databox.orchestration._factories import (
     SODA_DIR,
     dlt_destination,
     dlt_translator,
+    freshness_checks,
     soda_check,
 )
 
@@ -49,6 +52,12 @@ sqlmesh_asset_keys = [
     dg.AssetKey(["sqlmesh", "ebird", "fct_hotspot_species_diversity"]),
 ]
 
+FRESHNESS_SLAS: dict[dg.AssetKey, timedelta] = {
+    dg.AssetKey(["sqlmesh", "ebird", "fct_daily_bird_observations"]): timedelta(hours=30),
+    dg.AssetKey(["sqlmesh", "ebird", "dim_species"]): timedelta(days=7),
+    dg.AssetKey(["sqlmesh", "ebird", "fct_hotspot_species_diversity"]): timedelta(hours=30),
+}
+
 asset_checks: list[dg.AssetChecksDefinition] = [
     soda_check(
         dg.AssetKey(["sqlmesh", "ebird_staging", "stg_ebird_observations"]),
@@ -78,6 +87,7 @@ asset_checks: list[dg.AssetChecksDefinition] = [
         dg.AssetKey(["sqlmesh", "ebird", "fct_hotspot_species_diversity"]),
         SODA_DIR / "contracts/ebird/fct_hotspot_species_diversity.yaml",
     ),
+    *freshness_checks(FRESHNESS_SLAS),
 ]
 
 daily_pipeline = dg.define_asset_job(

--- a/packages/databox/databox/orchestration/domains/noaa.py
+++ b/packages/databox/databox/orchestration/domains/noaa.py
@@ -1,5 +1,7 @@
 """NOAA domain — dlt ingestion + SQLMesh marts + Soda checks."""
 
+from datetime import timedelta
+
 import dagster as dg
 import dlt
 from dagster import AssetExecutionContext
@@ -11,6 +13,7 @@ from databox.orchestration._factories import (
     SODA_DIR,
     dlt_destination,
     dlt_translator,
+    freshness_checks,
     soda_check,
 )
 
@@ -51,6 +54,10 @@ sqlmesh_asset_keys = [
     dg.AssetKey(["sqlmesh", "noaa", "fct_daily_weather"]),
 ]
 
+FRESHNESS_SLAS: dict[dg.AssetKey, timedelta] = {
+    dg.AssetKey(["sqlmesh", "noaa", "fct_daily_weather"]): timedelta(hours=48),
+}
+
 asset_checks: list[dg.AssetChecksDefinition] = [
     soda_check(
         dg.AssetKey(["sqlmesh", "noaa_staging", "stg_noaa_daily_weather"]),
@@ -64,6 +71,7 @@ asset_checks: list[dg.AssetChecksDefinition] = [
         dg.AssetKey(["sqlmesh", "noaa", "fct_daily_weather"]),
         SODA_DIR / "contracts/noaa/fct_daily_weather.yaml",
     ),
+    *freshness_checks(FRESHNESS_SLAS),
 ]
 
 daily_pipeline = dg.define_asset_job(

--- a/packages/databox/databox/orchestration/domains/usgs.py
+++ b/packages/databox/databox/orchestration/domains/usgs.py
@@ -1,5 +1,7 @@
 """USGS domain — dlt ingestion + SQLMesh marts + Soda checks."""
 
+from datetime import timedelta
+
 import dagster as dg
 import dlt
 from dagster import AssetExecutionContext
@@ -11,6 +13,7 @@ from databox.orchestration._factories import (
     SODA_DIR,
     dlt_destination,
     dlt_translator,
+    freshness_checks,
     soda_check,
 )
 
@@ -45,6 +48,10 @@ sqlmesh_asset_keys = [
     dg.AssetKey(["sqlmesh", "usgs", "fct_daily_streamflow"]),
 ]
 
+FRESHNESS_SLAS: dict[dg.AssetKey, timedelta] = {
+    dg.AssetKey(["sqlmesh", "usgs", "fct_daily_streamflow"]): timedelta(hours=30),
+}
+
 asset_checks: list[dg.AssetChecksDefinition] = [
     soda_check(
         dg.AssetKey(["sqlmesh", "usgs_staging", "stg_usgs_daily_values"]),
@@ -58,6 +65,7 @@ asset_checks: list[dg.AssetChecksDefinition] = [
         dg.AssetKey(["sqlmesh", "usgs", "fct_daily_streamflow"]),
         SODA_DIR / "contracts/usgs/fct_daily_streamflow.yaml",
     ),
+    *freshness_checks(FRESHNESS_SLAS),
 ]
 
 daily_pipeline = dg.define_asset_job(


### PR DESCRIPTION
## Summary

- Per-mart staleness SLAs via `build_last_update_freshness_checks`, one WARN-severity check per mart asset alongside existing Soda contracts.
- `freshness_violation_sensor` (disabled by default) scans `ASSET_CHECK_EVALUATION` events since last tick and logs one structured warning line per failure — forkers wire the log line into Slack / Email / PagerDuty.
- Coexists with the existing source-level `FreshnessPolicy` application: policy declares expected cadence in the UI, checks validate actual staleness at runtime.

### SLA table

| Asset | Max staleness |
|-------|---------------|
| `ebird/fct_daily_bird_observations` | 30h |
| `ebird/dim_species` | 7d |
| `ebird/fct_hotspot_species_diversity` | 30h |
| `noaa/fct_daily_weather` | 48h |
| `usgs/fct_daily_streamflow` | 30h |
| `analytics/fct_species_environment_daily` | 48h |
| `analytics/platform_health` | 2h |

Docs: [docs/freshness.md](docs/freshness.md).

Closes `ticket:freshness-slas`.

## Test plan

- [x] `uv run ruff check packages/` — clean
- [x] `uv run pytest -x -q` — 90 passed
- [x] `uv run python -c "from databox.orchestration.definitions import defs; ..."` — loads 45 asset specs
- [x] `uv run mkdocs build --strict` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)