### PR TITLE
Activate Rufous R2 production coordinates

### DIFF
--- a/.github/workflows/rufous-public.yaml
+++ b/.github/workflows/rufous-public.yaml
@@ -80,6 +80,13 @@ on:
 permissions:
   contents: read
 
+env:
+  # These are public release coordinates, not credentials. Keeping them in the
+  # reviewed workflow prevents a missing repository variable from silently
+  # disabling production while credentials remain secret-only.
+  RUFOUS_PUBLIC_DATA_URL: https://rufous-data.loughondata.com/rufous-public
+  RUFOUS_R2_BUCKET: rufous-public-data
+
 concurrency:
   group: rufous-public-${{ ((github.event_name == 'schedule') || (github.event_name == 'push' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main')) && 'production' || (github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number)) || format('nonproduction-{0}', github.run_id) }}
   # Never cancel an activation after immutable objects may have been written.
@@ -100,9 +107,7 @@ jobs:
     env:
       RELEASE_ENABLED: ${{ vars.RUF_PUBLIC_RELEASE_ENABLED }}
       PUBLIC_URL: ${{ vars.RUF_PUBLIC_URL }}
-      PUBLIC_DATA_URL: ${{ vars.RUF_PUBLIC_DATA_URL }}
       PAGES_PROJECT: ${{ vars.CLOUDFLARE_PAGES_PROJECT }}
-      R2_BUCKET: ${{ vars.RUF_R2_BUCKET }}
       CF_ACCOUNT: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       CF_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       R2_ACCESS_KEY_ID: ${{ secrets.RUF_R2_ACCESS_KEY_ID }}
@@ -116,12 +121,12 @@ jobs:
           if [[ "$RELEASE_ENABLED" != "true" ]]; then
             ready=false
           fi
-          for name in PUBLIC_URL PUBLIC_DATA_URL PAGES_PROJECT R2_BUCKET CF_ACCOUNT CF_TOKEN R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY; do
+          for name in PUBLIC_URL RUFOUS_PUBLIC_DATA_URL PAGES_PROJECT RUFOUS_R2_BUCKET CF_ACCOUNT CF_TOKEN R2_ACCESS_KEY_ID R2_SECRET_ACCESS_KEY; do
             if [[ -z "${!name}" ]]; then
               ready=false
             fi
           done
-          if [[ ! "$PUBLIC_URL" =~ ^https:// ]] || [[ "$PUBLIC_DATA_URL" != "https://rufous-data.loughondata.com/rufous-public" ]]; then
+          if [[ ! "$PUBLIC_URL" =~ ^https:// ]] || [[ "$RUFOUS_PUBLIC_DATA_URL" != "https://rufous-data.loughondata.com/rufous-public" ]]; then
             ready=false
           fi
           echo "production_ready=$ready" >> "$GITHUB_OUTPUT"
@@ -260,7 +265,7 @@ jobs:
           --output build/rufous-public-data
       - name: Build static public app
         env:
-          VITE_RUFOUS_DATA_BASE_URL: ${{ vars.RUF_PUBLIC_DATA_URL }}
+          VITE_RUFOUS_DATA_BASE_URL: ${{ env.RUFOUS_PUBLIC_DATA_URL }}
         run: npm --prefix app run build:public
       - name: Install production data contract
         run: |
@@ -282,7 +287,6 @@ jobs:
       - name: Preflight monotonic R2 activation before Pages deployment
         env:
           RUFOUS_R2_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          RUFOUS_R2_BUCKET: ${{ vars.RUF_R2_BUCKET }}
           RUFOUS_R2_ACCESS_KEY_ID: ${{ secrets.RUF_R2_ACCESS_KEY_ID }}
           RUFOUS_R2_SECRET_ACCESS_KEY: ${{ secrets.RUF_R2_SECRET_ACCESS_KEY }}
         run: >-
@@ -339,7 +343,6 @@ jobs:
       - name: Publish and activate audited immutable R2 release
         env:
           RUFOUS_R2_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          RUFOUS_R2_BUCKET: ${{ vars.RUF_R2_BUCKET }}
           RUFOUS_R2_ACCESS_KEY_ID: ${{ secrets.RUF_R2_ACCESS_KEY_ID }}
           RUFOUS_R2_SECRET_ACCESS_KEY: ${{ secrets.RUF_R2_SECRET_ACCESS_KEY }}
         run: >-

--- a/docs/rufous-public-release.md
+++ b/docs/rufous-public-release.md
@@ -225,10 +225,17 @@ Production is protected by `RUF_PUBLIC_RELEASE_ENABLED=true`. Repository
 variables are:
 
 - `RUF_PUBLIC_URL`
-- `RUF_PUBLIC_DATA_URL` — exactly
-  `https://rufous-data.loughondata.com/rufous-public`
-- `RUF_R2_BUCKET`
 - `CLOUDFLARE_PAGES_PROJECT`
+
+The non-secret public release coordinates are reviewed directly in
+`.github/workflows/rufous-public.yaml`:
+
+- `RUFOUS_PUBLIC_DATA_URL` — exactly
+  `https://rufous-data.loughondata.com/rufous-public`
+- `RUFOUS_R2_BUCKET` — exactly `rufous-public-data`
+
+Changing either coordinate therefore requires the same pull-request review and
+checks as changing the publisher instead of an unreviewed settings-page edit.
 
 Production secrets are:
 


### PR DESCRIPTION
Versions the dedicated public-data hostname and bucket in the reviewed workflow so production cannot be silently disabled by missing non-secret repository variables. The existing release gate and all credentials remain in GitHub settings/secrets.

Verified locally: focused public-release audit (11 tests), strict MkDocs build, workflow YAML parse, diff check, pre-commit hooks, and the 959-file credential scan.