### PR TITLE
fix(ci): prepare Polaris integration runner

### DIFF
--- a/.10x/tickets/2026-09-03-repair-polaris-workflow-runner-and-mask.md
+++ b/.10x/tickets/2026-09-03-repair-polaris-workflow-runner-and-mask.md
@@ -1,0 +1,26 @@
+Status: active
+Created: 2026-09-03
+Updated: 2026-09-03
+Parent: None
+Depends-On: .10x/tickets/done/2026-09-03-repair-hermetic-ci-and-iceberg-integration-gate.md
+
+# Repair Polaris integration runner and credential masking
+
+## Scope
+Repair the manual Polaris/S3 integration workflow after run 33793123271 reached compose startup but failed because the hosted runner lacks the Task CLI. Mask job-generated disposable Polaris/Postgres values before writing them to GitHub Actions environment output.
+
+## Acceptance criteria
+- The workflow installs a SHA-pinned Task CLI action before `task verify`.
+- Every generated Polaris/Postgres value is registered with GitHub Actions masking before it is exported.
+- Workflow tests prove both requirements structurally.
+- No trigger, production, IAM, or source behavior changes.
+
+## Evidence expectations
+Focused workflow tests and hosted manual rerun after merge.
+
+## Progress and notes
+- 2026-09-03: Run 33793123271 successfully assumed OIDC and started the disposable compose stack, then failed at `task verify` with `task: command not found`. Generated values appeared unmasked in logs; the stack was torn down and no verification/publication command ran.
+- 2026-09-03: Added a SHA-pinned Task setup action before verification and GitHub Actions masking for every generated Polaris/Postgres value. Focused structural workflow test passes with coverage disabled; full hosted CI and a new protected manual run remain required.
+
+## Blockers
+None.

--- a/.github/workflows/polaris-iceberg-integration.yaml
+++ b/.github/workflows/polaris-iceberg-integration.yaml
@@ -58,4 +58,13 @@ jobs:
         run: task verify
       - name: Stop disposable Polaris catalog
         if: always()
-        run: docker compose -f compose.iceberg.yml down --volumes
+        run: |
+          cleanup_variable() {
+            local name="$1"
+            printf '%s=%s' "$name" "${!name:-cleanup}"
+          }
+          env \
+            "$(cleanup_variable DATABOX_POLARIS_POSTGRES_PASSWORD)" \
+            "$(cleanup_variable DATABOX_POLARIS_CLIENT_ID)" \
+            "$(cleanup_variable DATABOX_POLARIS_CLIENT_SECRET)" \
+            docker compose -f compose.iceberg.yml down --volumes

--- a/.github/workflows/polaris-iceberg-integration.yaml
+++ b/.github/workflows/polaris-iceberg-integration.yaml
@@ -30,10 +30,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          postgres_password=$(openssl rand -hex 32)
+          client_id="github-actions-$(openssl rand -hex 8)"
+          client_secret=$(openssl rand -hex 32)
+          printf '::add-mask::%s\n' "$postgres_password"
+          printf '::add-mask::%s\n' "$client_id"
+          printf '::add-mask::%s\n' "$client_secret"
           {
-            echo "DATABOX_POLARIS_POSTGRES_PASSWORD=$(openssl rand -hex 32)"
-            echo "DATABOX_POLARIS_CLIENT_ID=github-actions-$(openssl rand -hex 8)"
-            echo "DATABOX_POLARIS_CLIENT_SECRET=$(openssl rand -hex 32)"
+            echo "DATABOX_POLARIS_POSTGRES_PASSWORD=$postgres_password"
+            echo "DATABOX_POLARIS_CLIENT_ID=$client_id"
+            echo "DATABOX_POLARIS_CLIENT_SECRET=$client_secret"
             echo "DATABOX_AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}"
             echo "DATABOX_AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}"
             echo "DATABOX_AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}"
@@ -47,6 +53,7 @@ jobs:
         run: uv sync --all-extras --dev --locked
       - name: Start disposable Polaris catalog
         run: docker compose -f compose.iceberg.yml up --wait --no-build polaris
+      - uses: go-task/setup-task@a00fbb05ce67b35648be3c78cbc9fd85354c757e # v2.2.0
       - name: Verify real Polaris/S3 source publication
         run: task verify
       - name: Stop disposable Polaris catalog

--- a/tests/platform/test_polaris_integration_workflow.py
+++ b/tests/platform/test_polaris_integration_workflow.py
@@ -67,3 +67,16 @@ def test_real_iceberg_integration_is_manual_protected_and_oidc_backed() -> None:
         index for index, step in enumerate(steps) if step.get("run") == "task verify"
     )
     assert task_setup_index < verify_index
+
+    cleanup_step = next(
+        step for step in steps if step.get("name") == "Stop disposable Polaris catalog"
+    )
+    assert cleanup_step["if"] == "always()"
+    assert "cleanup_variable()" in cleanup_step["run"]
+    assert '"${!name:-cleanup}"' in cleanup_step["run"]
+    for credential in (
+        "DATABOX_POLARIS_POSTGRES_PASSWORD",
+        "DATABOX_POLARIS_CLIENT_ID",
+        "DATABOX_POLARIS_CLIENT_SECRET",
+    ):
+        assert f"$(cleanup_variable {credential})" in cleanup_step["run"]

--- a/tests/platform/test_polaris_integration_workflow.py
+++ b/tests/platform/test_polaris_integration_workflow.py
@@ -48,6 +48,8 @@ def test_real_iceberg_integration_is_manual_protected_and_oidc_backed() -> None:
     )
     assert "openssl rand" in generation_step["run"]
     assert "$GITHUB_ENV" in generation_step["run"]
+    for credential in ("postgres_password", "client_id", "client_secret"):
+        assert f"printf '::add-mask::%s\\n' \"${credential}\"" in generation_step["run"]
     assert "DATABOX_AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}" in generation_step["run"]
     assert "DATABOX_AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}" in generation_step["run"]
     assert "DATABOX_AWS_SESSION_TOKEN=${AWS_SESSION_TOKEN}" in generation_step["run"]
@@ -56,4 +58,12 @@ def test_real_iceberg_integration_is_manual_protected_and_oidc_backed() -> None:
     assert "secrets.DATABOX_AWS_ACCESS_KEY_ID" not in WORKFLOW.read_text()
     assert "secrets.DATABOX_AWS_SECRET_ACCESS_KEY" not in WORKFLOW.read_text()
     assert "secrets.DATABOX_POLARIS_" not in WORKFLOW.read_text()
-    assert "task verify" in [step["run"] for step in steps if "run" in step]
+    task_setup_index = next(
+        index
+        for index, step in enumerate(steps)
+        if step.get("uses") == "go-task/setup-task@a00fbb05ce67b35648be3c78cbc9fd85354c757e"
+    )
+    verify_index = next(
+        index for index, step in enumerate(steps) if step.get("run") == "task verify"
+    )
+    assert task_setup_index < verify_index


### PR DESCRIPTION
Fix the protected manual Polaris/S3 verification after the first real run reached compose startup but failed because GitHub-hosted runners lack Task. Installs the Task CLI with a SHA-pinned action and masks all job-generated disposable Polaris/Postgres values before exporting them.