### PR TITLE
fix(ci): provision disposable Polaris catalog

### DIFF
--- a/.10x/tickets/2026-09-03-provision-disposable-polaris-catalog.md
+++ b/.10x/tickets/2026-09-03-provision-disposable-polaris-catalog.md
@@ -1,0 +1,25 @@
+Status: active
+Created: 2026-09-03
+Updated: 2026-09-03
+Parent: None
+Depends-On: .10x/tickets/2026-09-03-isolate-polaris-smoke-s3-prefix.md
+
+# Provision disposable Polaris integration catalog
+
+## Scope
+Provision the canonical `databox_lake` catalog in the workflow's fresh disposable Polaris database before verification, backed only by the run-isolated S3 warehouse location.
+
+## Acceptance criteria
+- The workflow creates `databox_lake` after Polaris becomes healthy and before `task verify`.
+- Storage location is exactly the configured run-isolated S3 prefix.
+- Provisioning uses existing ephemeral Polaris credentials and the OIDC role without logging secrets.
+- Structural tests cover ordering, catalog name, and isolated location.
+- No production prefix or persistent catalog is mutated.
+
+## Progress and notes
+- 2026-09-03: Run 33796171237 failed preflight with `Unable to find warehouse databox_lake`; no source or S3 publication occurred. Repository settings, `.env.example`, and active architecture decision confirm underscore-form `databox_lake` is canonical.
+
+- 2026-09-03: Added authenticated management-API provisioning after compose health and before verification. The canonical `databox_lake` catalog is bound to the exact run-isolated S3 location and configured with the OIDC role ARN; OAuth token output is masked.
+
+## Blockers
+None.

--- a/.github/workflows/polaris-iceberg-integration.yaml
+++ b/.github/workflows/polaris-iceberg-integration.yaml
@@ -54,6 +54,33 @@ jobs:
         run: uv sync --all-extras --dev --locked
       - name: Start disposable Polaris catalog
         run: docker compose -f compose.iceberg.yml up --wait --no-build polaris
+      - name: Provision isolated databox_lake catalog
+        env:
+          DATABOX_AWS_ROLE_ARN: ${{ secrets.DATABOX_AWS_ROLE_ARN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          token=$(curl --fail-with-body --silent \
+            --user "${DATABOX_POLARIS_CLIENT_ID}:${DATABOX_POLARIS_CLIENT_SECRET}" \
+            -H 'Polaris-Realm: POLARIS' \
+            -d grant_type=client_credentials \
+            -d scope=PRINCIPAL_ROLE:ALL \
+            http://127.0.0.1:8181/api/catalog/v1/oauth/tokens | jq -er .access_token)
+          printf '::add-mask::%s\n' "$token"
+          warehouse="s3://${DATABOX_AWS_S3_BUCKET}/${DATABOX_ICEBERG_WAREHOUSE_PREFIX}"
+          payload=$(jq -n \
+            --arg warehouse "$warehouse" \
+            --arg role_arn "$DATABOX_AWS_ROLE_ARN" \
+            '{catalog: {name: "databox_lake", type: "INTERNAL", readOnly: false,
+              properties: {"default-base-location": $warehouse},
+              storageConfigInfo: {storageType: "S3", allowedLocations: [$warehouse], roleArn: $role_arn}}}')
+          curl --fail-with-body --silent --show-error --output /dev/null \
+            -H "Authorization: Bearer ${token}" \
+            -H 'Accept: application/json' \
+            -H 'Content-Type: application/json' \
+            -H 'Polaris-Realm: POLARIS' \
+            -d "$payload" \
+            http://127.0.0.1:8181/api/management/v1/catalogs
       - uses: go-task/setup-task@a00fbb05ce67b35648be3c78cbc9fd85354c757e # v2.2.0
       - name: Verify real Polaris/S3 source publication
         run: task verify

--- a/tests/platform/test_polaris_integration_workflow.py
+++ b/tests/platform/test_polaris_integration_workflow.py
@@ -62,6 +62,26 @@ def test_real_iceberg_integration_is_manual_protected_and_oidc_backed() -> None:
     assert "secrets.DATABOX_AWS_ACCESS_KEY_ID" not in WORKFLOW.read_text()
     assert "secrets.DATABOX_AWS_SECRET_ACCESS_KEY" not in WORKFLOW.read_text()
     assert "secrets.DATABOX_POLARIS_" not in WORKFLOW.read_text()
+    start_index = next(
+        index
+        for index, step in enumerate(steps)
+        if step.get("name") == "Start disposable Polaris catalog"
+    )
+    provision_index = next(
+        index
+        for index, step in enumerate(steps)
+        if step.get("name") == "Provision isolated databox_lake catalog"
+    )
+    provision_step = steps[provision_index]
+    assert provision_step["env"] == {"DATABOX_AWS_ROLE_ARN": "${{ secrets.DATABOX_AWS_ROLE_ARN }}"}
+    assert 'name: "databox_lake"' in provision_step["run"]
+    assert (
+        'warehouse="s3://${DATABOX_AWS_S3_BUCKET}/${DATABOX_ICEBERG_WAREHOUSE_PREFIX}"'
+        in (provision_step["run"])
+    )
+    assert "allowedLocations: [$warehouse]" in provision_step["run"]
+    assert "roleArn: $role_arn" in provision_step["run"]
+    assert "::add-mask::%s" in provision_step["run"]
     task_setup_index = next(
         index
         for index, step in enumerate(steps)
@@ -70,7 +90,7 @@ def test_real_iceberg_integration_is_manual_protected_and_oidc_backed() -> None:
     verify_index = next(
         index for index, step in enumerate(steps) if step.get("run") == "task verify"
     )
-    assert task_setup_index < verify_index
+    assert start_index < provision_index < task_setup_index < verify_index
 
     cleanup_step = next(
         step for step in steps if step.get("name") == "Stop disposable Polaris catalog"


### PR DESCRIPTION
Provision canonical `databox_lake` in the disposable Polaris database before verification. The catalog is restricted to the run-specific integration S3 prefix and uses the existing OIDC role.

Validation: `uv run pytest tests/platform/test_polaris_integration_workflow.py -q --no-cov`; `git diff --check`.