### PR TITLE
fix(ci): preflight S3 integration access

### DIFF
--- a/.10x/tickets/2026-09-03-add-s3-integration-preflight.md
+++ b/.10x/tickets/2026-09-03-add-s3-integration-preflight.md
@@ -1,0 +1,22 @@
+Status: active
+Created: 2026-09-03
+Updated: 2026-09-03
+Parent: None
+Depends-On: .10x/tickets/2026-09-03-forward-oidc-session-token-to-dlt.md
+
+# Add S3 integration preflight
+
+## Scope
+Add direct read-only AWS identity and isolated-prefix checks before parallel source launch so integration failures report the exact AWS boundary rather than an interleaved truncated source traceback.
+
+## Acceptance criteria
+- Workflow calls STS identity and lists at most one object under the isolated prefix before source jobs.
+- No write or production prefix operation is introduced.
+- Structural workflow test covers ordering and arguments.
+
+## Progress and notes
+- 2026-09-03: dlt credential schema confirms `aws_session_token` is valid and current main forwards it. Run 33798027704 still failed during each source's first S3 listing, but parallel tailing omitted the AWS exception.
+- 2026-09-03: Added a read-only STS identity and isolated-prefix S3 listing preflight before source verification, with structural coverage for its exact commands and ordering.
+
+## Blockers
+None.

--- a/.github/workflows/polaris-iceberg-integration.yaml
+++ b/.github/workflows/polaris-iceberg-integration.yaml
@@ -81,6 +81,15 @@ jobs:
             -H 'Polaris-Realm: POLARIS' \
             -d "$payload" \
             http://127.0.0.1:8181/api/management/v1/catalogs
+      - name: Preflight AWS identity and isolated S3 prefix
+        shell: bash
+        run: |
+          set -euo pipefail
+          aws sts get-caller-identity
+          aws s3api list-objects-v2 \
+            --bucket "${DATABOX_AWS_S3_BUCKET}" \
+            --prefix "${DATABOX_ICEBERG_WAREHOUSE_PREFIX}" \
+            --max-items 1
       - uses: go-task/setup-task@a00fbb05ce67b35648be3c78cbc9fd85354c757e # v2.2.0
       - name: Verify real Polaris/S3 source publication
         run: task verify

--- a/tests/platform/test_polaris_integration_workflow.py
+++ b/tests/platform/test_polaris_integration_workflow.py
@@ -104,3 +104,34 @@ def test_real_iceberg_integration_is_manual_protected_and_oidc_backed() -> None:
         "DATABOX_POLARIS_CLIENT_SECRET",
     ):
         assert f"$(cleanup_variable {credential})" in cleanup_step["run"]
+
+
+def test_s3_preflight_is_read_only_scoped_and_runs_before_source_verification() -> None:
+    workflow = yaml.load(WORKFLOW.read_text(), Loader=yaml.BaseLoader)
+    steps = workflow["jobs"]["verify"]["steps"]
+
+    provision_index = next(
+        index
+        for index, step in enumerate(steps)
+        if step.get("name") == "Provision isolated databox_lake catalog"
+    )
+    preflight_index = next(
+        index
+        for index, step in enumerate(steps)
+        if step.get("name") == "Preflight AWS identity and isolated S3 prefix"
+    )
+    verify_index = next(
+        index for index, step in enumerate(steps) if step.get("run") == "task verify"
+    )
+    preflight_step = steps[preflight_index]
+
+    assert provision_index < preflight_index < verify_index
+    assert preflight_step["shell"] == "bash"
+    assert preflight_step["run"].splitlines() == [
+        "set -euo pipefail",
+        "aws sts get-caller-identity",
+        "aws s3api list-objects-v2 \\",
+        '  --bucket "${DATABOX_AWS_S3_BUCKET}" \\',
+        '  --prefix "${DATABOX_ICEBERG_WAREHOUSE_PREFIX}" \\',
+        "  --max-items 1",
+    ]


### PR DESCRIPTION
## Summary
- add a read-only AWS identity and isolated-prefix S3 preflight to the Polaris integration workflow
- list at most one object using the workflow bucket and run-isolated warehouse prefix
- structurally test exact commands and ordering before source verification

## Test plan
- `uv run pytest tests/platform/test_polaris_integration_workflow.py --no-cov`