### PR TITLE
fix(ci): grant Polaris integration catalog access

### DIFF
--- a/.10x/tickets/2026-09-03-grant-disposable-polaris-catalog-access.md
+++ b/.10x/tickets/2026-09-03-grant-disposable-polaris-catalog-access.md
@@ -1,0 +1,25 @@
+Status: active
+Created: 2026-09-03
+Updated: 2026-09-03
+Parent: None
+Depends-On: .10x/tickets/2026-09-03-provision-disposable-polaris-catalog.md
+
+# Grant disposable Polaris catalog access
+
+## Scope
+Complete disposable Polaris provisioning by granting the bootstrap principal role catalog content-management access to `databox_lake` before source execution.
+
+## Acceptance criteria
+- Provisioning creates a catalog role for `databox_lake`.
+- It grants `CATALOG_MANAGE_CONTENT` to that catalog role.
+- It grants the catalog role to the authenticated bootstrap principal role.
+- Steps occur before source execution and expose no credentials.
+- Structural tests cover exact authorization sequence.
+
+## Progress and notes
+- 2026-09-03: Run 33799740982 passed AWS/S3 preflight and catalog creation, then Polaris returned 403 for every table-create request. IAM needs no further change.
+
+- 2026-09-03: Verified the exact Polaris 1.7 contracts from tag `apache-polaris-1.7.0`: catalog-role creation, `CATALOG_MANAGE_CONTENT` grant, and assignment to bootstrap role `service_admin`. Implemented the ordered provisioning sequence with structural coverage.
+
+## Blockers
+None.

--- a/.github/workflows/polaris-iceberg-integration.yaml
+++ b/.github/workflows/polaris-iceberg-integration.yaml
@@ -74,13 +74,34 @@ jobs:
             '{catalog: {name: "databox_lake", type: "INTERNAL", readOnly: false,
               properties: {"default-base-location": $warehouse},
               storageConfigInfo: {storageType: "S3", allowedLocations: [$warehouse], roleArn: $role_arn}}}')
+          management_url=http://127.0.0.1:8181/api/management/v1
           curl --fail-with-body --silent --show-error --output /dev/null \
             -H "Authorization: Bearer ${token}" \
             -H 'Accept: application/json' \
             -H 'Content-Type: application/json' \
             -H 'Polaris-Realm: POLARIS' \
             -d "$payload" \
-            http://127.0.0.1:8181/api/management/v1/catalogs
+            "${management_url}/catalogs"
+          curl --fail-with-body --silent --show-error --output /dev/null \
+            -H "Authorization: Bearer ${token}" \
+            -H 'Content-Type: application/json' \
+            -H 'Polaris-Realm: POLARIS' \
+            -d '{"catalogRole":{"name":"integration_writer","properties":{}}}' \
+            "${management_url}/catalogs/databox_lake/catalog-roles"
+          curl --fail-with-body --silent --show-error --output /dev/null \
+            -X PUT \
+            -H "Authorization: Bearer ${token}" \
+            -H 'Content-Type: application/json' \
+            -H 'Polaris-Realm: POLARIS' \
+            -d '{"type":"catalog","privilege":"CATALOG_MANAGE_CONTENT"}' \
+            "${management_url}/catalogs/databox_lake/catalog-roles/integration_writer/grants"
+          curl --fail-with-body --silent --show-error --output /dev/null \
+            -X PUT \
+            -H "Authorization: Bearer ${token}" \
+            -H 'Content-Type: application/json' \
+            -H 'Polaris-Realm: POLARIS' \
+            -d '{"catalogRole":{"name":"integration_writer"}}' \
+            "${management_url}/principal-roles/service_admin/catalog-roles/databox_lake"
       - name: Preflight AWS identity and isolated S3 prefix
         shell: bash
         run: |

--- a/tests/platform/test_polaris_integration_workflow.py
+++ b/tests/platform/test_polaris_integration_workflow.py
@@ -82,6 +82,20 @@ def test_real_iceberg_integration_is_manual_protected_and_oidc_backed() -> None:
     assert "allowedLocations: [$warehouse]" in provision_step["run"]
     assert "roleArn: $role_arn" in provision_step["run"]
     assert "::add-mask::%s" in provision_step["run"]
+    provision_script = provision_step["run"]
+    create_catalog_role = provision_script.index(
+        '"${management_url}/catalogs/databox_lake/catalog-roles"'
+    )
+    grant_content = provision_script.index(
+        '"${management_url}/catalogs/databox_lake/catalog-roles/integration_writer/grants"'
+    )
+    assign_to_service_admin = provision_script.index(
+        '"${management_url}/principal-roles/service_admin/catalog-roles/databox_lake"'
+    )
+    assert create_catalog_role < grant_content < assign_to_service_admin
+    assert '{"catalogRole":{"name":"integration_writer","properties":{}}}' in provision_script
+    assert '{"type":"catalog","privilege":"CATALOG_MANAGE_CONTENT"}' in provision_script
+    assert '{"catalogRole":{"name":"integration_writer"}}' in provision_script
     task_setup_index = next(
         index
         for index, step in enumerate(steps)


### PR DESCRIPTION
## Summary
- create a disposable Polaris catalog role
- grant CATALOG_MANAGE_CONTENT and assign it to service_admin
- verify the exact ordered Polaris 1.7 authorization sequence

## Validation
- uv run pytest tests/platform/test_polaris_integration_workflow.py -q --no-cov
- uv run ruff check tests/platform/test_polaris_integration_workflow.py
- git diff --check