### PR TITLE
fix(ci): split Polaris source verification matrix

### DIFF
--- a/.10x/tickets/2026-09-03-split-polaris-integration-source-matrix.md
+++ b/.10x/tickets/2026-09-03-split-polaris-integration-source-matrix.md
@@ -1,0 +1,31 @@
+Status: active
+Created: 2026-09-03
+Updated: 2026-09-03
+Parent: None
+Depends-On: .10x/tickets/2026-09-03-add-s3-integration-preflight.md
+
+# Split Polaris integration into a source matrix
+
+## Scope
+Replace the opaque parallel all-source verification step with one protected matrix job per refresh-eligible source. Each job must use its own disposable Polaris/Postgres catalog and source-specific run-isolated S3 prefix, execute exactly one real source, skip unrelated SQLMesh transformation, and retain independent GitHub job attribution.
+
+## Acceptance criteria
+- Matrix covers ebird, gbif, xeno_canto, noaa, usgs, and usgs_earthquakes exactly once.
+- Each job executes one named real source through the production Dagster/dlt path with `--skip-sqlmesh`.
+- Each source uses `integration/<run>/<attempt>/<source>/warehouse` and a disposable catalog.
+- One source failure does not suppress other source execution (`fail-fast: false`).
+- Existing OIDC, protected environment, masking, catalog provisioning/authorization, S3 preflight, and cleanup protections remain.
+- Workflow tests prove matrix membership, command, isolation, and attribution.
+
+## Explicit exclusions
+- Durable production refresh behavior.
+- SQLMesh verification.
+- Provider mocking.
+- IAM changes.
+
+## Progress and notes
+- 2026-09-03: Run 33803401394 proved Xeno-canto end-to-end publication. CloudTrail showed all six Polaris self-assume calls succeeded; combined parallel logs discarded five source-specific failures, motivating independent jobs.
+- 2026-09-03: Split the protected workflow into six independent, non-fail-fast matrix jobs. Each runs one real source without SQLMesh against its own disposable Polaris catalog and source-scoped integration prefix. Focused structural tests, Ruff, pre-commit, secret scan, YAML parse, and diff checks pass; hosted CI and protected matrix execution remain.
+
+## Blockers
+None.

--- a/.github/workflows/polaris-iceberg-integration.yaml
+++ b/.github/workflows/polaris-iceberg-integration.yaml
@@ -9,12 +9,22 @@ permissions:
 
 jobs:
   verify:
-    name: Real Polaris/S3 smoke verification
+    name: Real Polaris/S3 source verification (${{ matrix.source }})
     runs-on: ubuntu-latest
     environment: polaris-iceberg-integration
+    strategy:
+      fail-fast: false
+      matrix:
+        source:
+          - ebird
+          - gbif
+          - xeno_canto
+          - noaa
+          - usgs
+          - usgs_earthquakes
     env:
       DATABOX_AWS_S3_BUCKET: ${{ secrets.DATABOX_AWS_S3_BUCKET }}
-      DATABOX_ICEBERG_WAREHOUSE_PREFIX: integration/${{ github.run_id }}/${{ github.run_attempt }}/warehouse
+      DATABOX_ICEBERG_WAREHOUSE_PREFIX: integration/${{ github.run_id }}/${{ github.run_attempt }}/${{ matrix.source }}/warehouse
       DATABOX_AWS_REGION: us-west-1
       EBIRD_API_TOKEN: ${{ secrets.EBIRD_API_TOKEN }}
       NOAA_API_TOKEN: ${{ secrets.NOAA_API_TOKEN }}
@@ -111,9 +121,10 @@ jobs:
             --bucket "${DATABOX_AWS_S3_BUCKET}" \
             --prefix "${DATABOX_ICEBERG_WAREHOUSE_PREFIX}" \
             --max-items 1
-      - uses: go-task/setup-task@a00fbb05ce67b35648be3c78cbc9fd85354c757e # v2.2.0
       - name: Verify real Polaris/S3 source publication
-        run: task verify
+        run: >-
+          .venv/bin/python scripts/sources/load_dlt_iceberg.py
+          --source "${{ matrix.source }}" --skip-sqlmesh
       - name: Stop disposable Polaris catalog
         if: always()
         run: |

--- a/tests/platform/test_polaris_integration_workflow.py
+++ b/tests/platform/test_polaris_integration_workflow.py
@@ -15,7 +15,21 @@ def test_real_iceberg_integration_is_manual_protected_and_oidc_backed() -> None:
     assert workflow["permissions"] == {"contents": "read", "id-token": "write"}
 
     job = workflow["jobs"]["verify"]
+    assert job["name"] == "Real Polaris/S3 source verification (${{ matrix.source }})"
     assert job["environment"] == "polaris-iceberg-integration"
+    assert job["strategy"] == {
+        "fail-fast": "false",
+        "matrix": {
+            "source": [
+                "ebird",
+                "gbif",
+                "xeno_canto",
+                "noaa",
+                "usgs",
+                "usgs_earthquakes",
+            ]
+        },
+    }
     assert "inputs" not in workflow["on"]["workflow_dispatch"]
     provider_names = (
         "EBIRD" + "_API_" + "TOKEN",
@@ -24,7 +38,7 @@ def test_real_iceberg_integration_is_manual_protected_and_oidc_backed() -> None:
     )
     assert job["env"]["DATABOX_AWS_S3_BUCKET"] == "${{ secrets.DATABOX_AWS_S3_BUCKET }}"
     assert job["env"]["DATABOX_ICEBERG_WAREHOUSE_PREFIX"] == (
-        "integration/${{ github.run_id }}/${{ github.run_attempt }}/warehouse"
+        "integration/${{ github.run_id }}/${{ github.run_attempt }}/${{ matrix.source }}/warehouse"
     )
     assert job["env"]["DATABOX_ICEBERG_WAREHOUSE_PREFIX"] != "warehouse"
     assert job["env"]["DATABOX_AWS_REGION"] == "us-west-1"
@@ -96,15 +110,17 @@ def test_real_iceberg_integration_is_manual_protected_and_oidc_backed() -> None:
     assert '{"catalogRole":{"name":"integration_writer","properties":{}}}' in provision_script
     assert '{"type":"catalog","privilege":"CATALOG_MANAGE_CONTENT"}' in provision_script
     assert '{"catalogRole":{"name":"integration_writer"}}' in provision_script
-    task_setup_index = next(
+    assert not any(step.get("uses", "").startswith("go-task/setup-task@") for step in steps)
+    verify_index = next(
         index
         for index, step in enumerate(steps)
-        if step.get("uses") == "go-task/setup-task@a00fbb05ce67b35648be3c78cbc9fd85354c757e"
+        if step.get("name") == "Verify real Polaris/S3 source publication"
     )
-    verify_index = next(
-        index for index, step in enumerate(steps) if step.get("run") == "task verify"
+    assert steps[verify_index]["run"] == (
+        ".venv/bin/python scripts/sources/load_dlt_iceberg.py "
+        '--source "${{ matrix.source }}" --skip-sqlmesh'
     )
-    assert start_index < provision_index < task_setup_index < verify_index
+    assert start_index < provision_index < verify_index
 
     cleanup_step = next(
         step for step in steps if step.get("name") == "Stop disposable Polaris catalog"
@@ -135,7 +151,9 @@ def test_s3_preflight_is_read_only_scoped_and_runs_before_source_verification() 
         if step.get("name") == "Preflight AWS identity and isolated S3 prefix"
     )
     verify_index = next(
-        index for index, step in enumerate(steps) if step.get("run") == "task verify"
+        index
+        for index, step in enumerate(steps)
+        if step.get("name") == "Verify real Polaris/S3 source publication"
     )
     preflight_step = steps[preflight_index]
 


### PR DESCRIPTION
## Summary
- run each refresh-eligible source in an independent protected matrix job
- isolate each source under its own disposable Polaris catalog and S3 prefix
- execute the real source path directly without unrelated SQLMesh work

## Validation
- `uv run pytest tests/platform/test_polaris_integration_workflow.py -q --no-cov`
- `uv run pre-commit run --all-files`
- secret scan, YAML parse, and `git diff --check`